### PR TITLE
Syntactical improvements to span() and trace()

### DIFF
--- a/src/common/integrations/langgraph.ts
+++ b/src/common/integrations/langgraph.ts
@@ -16,7 +16,7 @@ import { BaseTracer } from "@langchain/core/tracers/base";
 import { getEnvironmentVariable } from "@langchain/core/utils/env";
 
 import { v4 as uuidv4 } from 'uuid';
-import { Tracer, TraceClient, SpanType, currentSpanAsyncLocalStorage, TraceEntry } from "../tracer"; // Adjust path
+import { Tracer, TraceClient, SpanType, TraceEntry } from "../tracer"; // Adjust path
 
 // --- Global Handler Setup (REMOVED - No longer needed with context propagation) ---
 
@@ -67,7 +67,7 @@ export class JudgevalLanggraphCallbackHandler extends BaseCallbackHandler {
         this.runIdToSpanId[lcRunId] = spanId; // Map Langchain runId to our new spanId
 
         // Get parent span ID from the current async context
-        const parentSpanId = currentSpanAsyncLocalStorage.getStore();
+        const parentSpanId = this.tracer.getCurrentTrace()?.currentSpanId;
         // Calculate depth based on parent
         let depth = 0;
         if (parentSpanId) {

--- a/src/demo/ethan-demo.ts
+++ b/src/demo/ethan-demo.ts
@@ -2,12 +2,16 @@ import { Tracer } from "../common/tracer";
 
 const tracer = Tracer.getInstance({ projectName: "ethan-judgeval-js-testing" });
 
-const say = tracer.observe({ name: "say", spanType: "tool" })((what: string) => {
-  console.log(`Ethan says, "${what}!"`);
-  return `Ethan said, "${what}!"`;
+const print = tracer.observe({ name: "print", spanType: "tool" })((what: any) => {
+  console.log(what);
+  return what;
 });
 
-const input = "Hello, World!";
+const say = tracer.observe({ name: "say", spanType: "tool" })((what: string) => {
+  return print(`Ethan says, "${what}!"`);
+});
+
+const input = "Hello, World";
 const output = say(input);
 console.log(output);
 
@@ -19,6 +23,6 @@ console.log(output);
  * Functions exactly the same. You can yield or return stuff inside it and it will
  * really yield/return! (versus callbacks, which require a little extra)
  */
-for (const trace of tracer.trace("say")) {
-  console.log(trace);
-}
+// for (const trace of tracer.trace("say")) {
+//   console.log(trace);
+// }


### PR DESCRIPTION
In Python, you can do:
```py
with tracer.trace(...) as trace:
  print(trace)
```

This PR replicates this behavior using:
```ts
for (const trace of tracer.trace(...)) {
  console.log(trace);
}
```

This has the benefit of yield having the expected behavior from within the block. Additionally, the syntax for defining this behavior is very similar to Python's and relies on generators. The only downside is that return will exit before the span/trace can complete, but that may be expected behavior depending on what you're looking for.