### PR TITLE
JUD-7589: require Summary and Testing sections in every PR

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Summary
+
+<!--
+Required. Describe what this PR changes and why.
+A PR with an empty Summary section is blocked from merging.
+-->
+
+## Testing
+
+<!--
+Required. Describe how you verified these changes:
+tests added or run, manual steps, screenshots, etc.
+A PR with an empty Testing section is blocked from merging.
+-->

--- a/.github/workflows/pr-body-check.yaml
+++ b/.github/workflows/pr-body-check.yaml
@@ -1,0 +1,70 @@
+name: PR body check
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+    branches:
+      - main
+      - production
+  merge_group:
+    types: [checks_requested]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-body-check-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  required-sections:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate Summary and Testing sections
+        if: ${{ github.event_name == 'pull_request' }}
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          python3 - <<'PY'
+          import os, re, sys
+
+          body = os.environ.get("PR_BODY", "") or ""
+          # Drop the template's HTML comment guidance before checking for content.
+          body = re.sub(r"<!--.*?-->", "", body, flags=re.DOTALL)
+          body = body.replace("\r\n", "\n")
+
+          def section(name):
+              pattern = re.compile(
+                  r"^#{1,6}[ \t]+" + re.escape(name) + r"[ \t]*$(.*?)(?=^##[ \t]|\Z)",
+                  re.IGNORECASE | re.MULTILINE | re.DOTALL,
+              )
+              m = pattern.search(body)
+              return m.group(1).strip() if m else None
+
+          errors = []
+          for name in ("Summary", "Testing"):
+              content = section(name)
+              if content is None:
+                  errors.append(
+                      f"Missing required '## {name}' section. Keep it from the PR template."
+                  )
+              elif not content:
+                  errors.append(
+                      f"The '## {name}' section is empty. Fill it out before merging."
+                  )
+
+          if errors:
+              for e in errors:
+                  print(f"::error::{e}")
+              print(
+                  "\nEvery PR must keep the template's Summary and Testing sections, "
+                  "each filled out."
+              )
+              sys.exit(1)
+
+          print("PR body has non-empty Summary and Testing sections.")
+          PY
+
+      - name: Skip on merge_group
+        if: ${{ github.event_name == 'merge_group' }}
+        run: echo "merge_group event; PR body was validated on the pull_request event."


### PR DESCRIPTION
## Summary

Ports JudgmentLabs/judgment-mono#2679 to this repo. Every PR now gets a template with mandatory **Summary** and **Testing** sections, and a CI check fails when either is missing or empty.

- `.github/pull_request_template.md` — GitHub prefills this into every new PR body. Contains `## Summary` and `## Testing` headings with HTML-comment guidance.
- `.github/workflows/pr-body-check.yaml` — runs on `pull_request` (to `main`/`production`) and `merge_group`. The `required-sections` job fails when the body is missing `## Summary` or `## Testing`, or when either section is empty. HTML-comment guidance is stripped before the emptiness check, so submitting the unedited template is rejected.

Runner is `ubuntu-latest` (the source PR used a Blacksmith runner; this repo's other workflows use `ubuntu-latest`).

### Follow-up needed to actually block merge

The workflow only reports a pass/fail status context. To enforce it, add the **`required-sections`** check (workflow "PR body check") to the `main` (and `production`) branch protection ruleset as a required status check. The job runs on `merge_group` too, so the merge queue receives the same context.

Linear: JUD-7589

## Testing

- Identical parser logic to judgment-mono#2679, validated there against: unedited template (both empty → fail), only-Summary-filled (fail), both filled (pass), both filled with a `###` subheading (pass), missing-body / no headings (fail), null body (fail).
- Workflow YAML re-parsed after the `runs-on` change; `on` triggers (`pull_request`, `merge_group`) and single `required-sections` job confirmed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/judgmentlabs/judgeval-js/pull/67" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->