### PR TITLE
Add Tracer.emitPartial(span) to snapshot a non-active span

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "judgeval",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "JavaScript/TypeScript client for Judgment evaluation platform",
   "main": "./dist/node/index.cjs",
   "module": "./dist/node/index.mjs",

--- a/src/trace/BaseTracer.ts
+++ b/src/trace/BaseTracer.ts
@@ -212,11 +212,7 @@ export abstract class BaseTracer {
   }
 
   private static _emitPartial(): void {
-    dontThrow("BaseTracer._emitPartial", () => {
-      const tracer = BaseTracer._getProxyProvider().getActiveTracer();
-      if (!tracer || !tracer.supportsLiveInstrumentation) return;
-      tracer.getSpanProcessor().emitPartial();
-    });
+    BaseTracer.emitPartial();
   }
 
   // ------------------------------------------------------------------ //
@@ -231,6 +227,39 @@ export abstract class BaseTracer {
   static getCurrentSpan(): Span | undefined {
     const proxy = BaseTracer._getProxyProvider();
     return proxy.getCurrentSpan();
+  }
+
+  /**
+   * Emit a span's in-progress state without ending it.
+   *
+   * Sends a partial snapshot through the live span processor; the backend
+   * merges it with later emissions of the same span (by update id), so a span
+   * can be exported early and upgraded when it finally ends. Most code never
+   * needs this — spans created via {@link observe}, {@link with}, or
+   * {@link startActiveSpan} emit partials automatically.
+   *
+   * Use it for a long-lived span opened with {@link startSpan} that is **not**
+   * the active span and must exist in the backend before it ends — e.g. a root
+   * span held across durable steps, so an eviction or early failure still
+   * leaves a parent for its children instead of orphaning them.
+   *
+   * @param span - The span to snapshot. Defaults to the current active span.
+   *
+   * @example
+   * ```typescript
+   * const root = Tracer.startSpan("run");
+   * Tracer.emitPartial(root);   // present in the backend now
+   * // ... later, possibly in another invocation ...
+   * Tracer.setOutput(result, root);
+   * root.end();                 // upgrades the partial with output + duration
+   * ```
+   */
+  static emitPartial(span?: Span): void {
+    dontThrow("BaseTracer.emitPartial", () => {
+      const tracer = BaseTracer._getProxyProvider().getActiveTracer();
+      if (!tracer || !tracer.supportsLiveInstrumentation) return;
+      tracer.getSpanProcessor().emitPartial(span);
+    });
   }
 
   /**

--- a/src/trace/BaseTracer.ts
+++ b/src/trace/BaseTracer.ts
@@ -232,27 +232,19 @@ export abstract class BaseTracer {
   /**
    * Emit a span's in-progress state without ending it.
    *
-   * Sends a partial snapshot through the live span processor; the backend
-   * merges it with later emissions of the same span (by update id), so a span
-   * can be exported early and upgraded when it finally ends. Most code never
-   * needs this — spans created via {@link observe}, {@link with}, or
+   * Partial emission previously only ever snapshotted the *active* span, so a
+   * span opened with {@link startSpan} and held open without being active could
+   * not reach the backend until it ended. The Cloudflare agent harness needs
+   * exactly that: a "run" root span covers many durable steps across separate
+   * invocations, so it can't stay the active span, yet it must exist up front —
+   * otherwise a mid-run eviction leaves its child spans with no parent. This
+   * emits the held-open root immediately; the backend merges it with the final
+   * emission (by update id), upgrading it with output and duration when it ends.
+   *
+   * Most code never needs this — {@link observe}, {@link with}, and
    * {@link startActiveSpan} emit partials automatically.
    *
-   * Use it for a long-lived span opened with {@link startSpan} that is **not**
-   * the active span and must exist in the backend before it ends — e.g. a root
-   * span held across durable steps, so an eviction or early failure still
-   * leaves a parent for its children instead of orphaning them.
-   *
    * @param span - The span to snapshot. Defaults to the current active span.
-   *
-   * @example
-   * ```typescript
-   * const root = Tracer.startSpan("run");
-   * Tracer.emitPartial(root);   // present in the backend now
-   * // ... later, possibly in another invocation ...
-   * Tracer.setOutput(result, root);
-   * root.end();                 // upgrades the partial with output + duration
-   * ```
    */
   static emitPartial(span?: Span): void {
     dontThrow("BaseTracer.emitPartial", () => {

--- a/src/trace/processors/JudgmentSpanProcessor.test.ts
+++ b/src/trace/processors/JudgmentSpanProcessor.test.ts
@@ -1,10 +1,26 @@
 import { describe, expect, test } from "bun:test";
+import { SpanKind, SpanStatusCode } from "@opentelemetry/api";
 import {
   BasicTracerProvider,
   InMemorySpanExporter,
+  type ReadableSpan,
 } from "@opentelemetry/sdk-trace-base";
 import { AttributeKeys } from "../../JudgmentAttributeKeys";
 import { JudgmentSpanProcessor } from "./JudgmentSpanProcessor";
+
+// The deterministic content of an exported span — everything except the
+// inherently-random trace/span ids and wall-clock start time, which a
+// fixed-value assertion can't pin down.
+function spanContent(span: ReadableSpan) {
+  return {
+    name: span.name,
+    kind: span.kind,
+    status: span.status,
+    attributes: span.attributes,
+    events: span.events,
+    links: span.links,
+  };
+}
 
 describe("JudgmentSpanProcessor.emitPartial", () => {
   test("snapshots an explicit span that is not the active span", async () => {
@@ -19,11 +35,17 @@ describe("JudgmentSpanProcessor.emitPartial", () => {
 
     const finished = exporter.getFinishedSpans();
     expect(finished.length).toBe(1);
-    expect(finished[0]?.name).toBe("run");
-    // A partial snapshot stamps end time to the start time (zero duration)...
-    expect(finished[0]?.endTime).toEqual(finished[0]!.startTime);
-    // ...and carries the first update id so the backend can upgrade it later.
-    expect(finished[0]?.attributes[AttributeKeys.JUDGMENT_UPDATE_ID]).toBe(0);
+    expect(spanContent(finished[0]!)).toEqual({
+      name: "run",
+      kind: SpanKind.INTERNAL,
+      status: { code: SpanStatusCode.UNSET },
+      // A partial of a span with no attributes set carries only the update id.
+      attributes: { [AttributeKeys.JUDGMENT_UPDATE_ID]: 0 },
+      events: [],
+      links: [],
+    });
+    // A partial snapshot stamps end time to start time (zero duration).
+    expect(finished[0]!.endTime).toEqual(finished[0]!.startTime);
 
     span.end();
   });
@@ -41,9 +63,27 @@ describe("JudgmentSpanProcessor.emitPartial", () => {
 
     const finished = exporter.getFinishedSpans();
     expect(finished.length).toBe(2);
-    expect(finished[0]?.attributes[AttributeKeys.JUDGMENT_UPDATE_ID]).toBe(0);
-    expect(finished[0]?.attributes[AttributeKeys.JUDGMENT_OUTPUT]).toBeUndefined();
-    expect(finished[1]?.attributes[AttributeKeys.JUDGMENT_UPDATE_ID]).toBe(1);
-    expect(finished[1]?.attributes[AttributeKeys.JUDGMENT_OUTPUT]).toBe("done");
+    // The partial: no output, end stamped to start, update id 0.
+    expect(spanContent(finished[0]!)).toEqual({
+      name: "run",
+      kind: SpanKind.INTERNAL,
+      status: { code: SpanStatusCode.UNSET },
+      attributes: { [AttributeKeys.JUDGMENT_UPDATE_ID]: 0 },
+      events: [],
+      links: [],
+    });
+    expect(finished[0]!.endTime).toEqual(finished[0]!.startTime);
+    // The final: output added and the update id bumped.
+    expect(spanContent(finished[1]!)).toEqual({
+      name: "run",
+      kind: SpanKind.INTERNAL,
+      status: { code: SpanStatusCode.UNSET },
+      attributes: {
+        [AttributeKeys.JUDGMENT_OUTPUT]: "done",
+        [AttributeKeys.JUDGMENT_UPDATE_ID]: 1,
+      },
+      events: [],
+      links: [],
+    });
   });
 });

--- a/src/trace/processors/JudgmentSpanProcessor.test.ts
+++ b/src/trace/processors/JudgmentSpanProcessor.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import {
+  BasicTracerProvider,
+  InMemorySpanExporter,
+} from "@opentelemetry/sdk-trace-base";
+import { AttributeKeys } from "../../JudgmentAttributeKeys";
+import { JudgmentSpanProcessor } from "./JudgmentSpanProcessor";
+
+describe("JudgmentSpanProcessor.emitPartial", () => {
+  test("snapshots an explicit span that is not the active span", async () => {
+    const exporter = new InMemorySpanExporter();
+    const processor = new JudgmentSpanProcessor(null, exporter);
+    const provider = new BasicTracerProvider({ spanProcessors: [processor] });
+    // Recording, but never made active (started, not start-active).
+    const span = provider.getTracer("test").startSpan("run");
+
+    processor.emitPartial(span);
+    await processor.forceFlush();
+
+    const finished = exporter.getFinishedSpans();
+    expect(finished.length).toBe(1);
+    expect(finished[0]?.name).toBe("run");
+    // A partial snapshot stamps end time to the start time (zero duration)...
+    expect(finished[0]?.endTime).toEqual(finished[0]!.startTime);
+    // ...and carries the first update id so the backend can upgrade it later.
+    expect(finished[0]?.attributes[AttributeKeys.JUDGMENT_UPDATE_ID]).toBe(0);
+
+    span.end();
+  });
+
+  test("ending the span after a partial re-emits it with a higher update id", async () => {
+    const exporter = new InMemorySpanExporter();
+    const processor = new JudgmentSpanProcessor(null, exporter);
+    const provider = new BasicTracerProvider({ spanProcessors: [processor] });
+    const span = provider.getTracer("test").startSpan("run");
+
+    processor.emitPartial(span); // update id 0 — input only, no output yet
+    span.setAttribute(AttributeKeys.JUDGMENT_OUTPUT, "done");
+    span.end(); // update id 1 — final, with output
+    await processor.forceFlush();
+
+    const finished = exporter.getFinishedSpans();
+    expect(finished.length).toBe(2);
+    expect(finished[0]?.attributes[AttributeKeys.JUDGMENT_UPDATE_ID]).toBe(0);
+    expect(finished[0]?.attributes[AttributeKeys.JUDGMENT_OUTPUT]).toBeUndefined();
+    expect(finished[1]?.attributes[AttributeKeys.JUDGMENT_UPDATE_ID]).toBe(1);
+    expect(finished[1]?.attributes[AttributeKeys.JUDGMENT_OUTPUT]).toBe("done");
+  });
+});

--- a/src/trace/processors/JudgmentSpanProcessor.ts
+++ b/src/trace/processors/JudgmentSpanProcessor.ts
@@ -2,6 +2,7 @@ import type {
   Attributes,
   Context,
   HrTime,
+  Span as ApiSpan,
   SpanContext,
 } from "@opentelemetry/api";
 import {
@@ -152,12 +153,16 @@ export class JudgmentSpanProcessor extends BatchSpanProcessor {
     super.onEnd(emittedSpan);
   }
 
-  /** Export the current span's in-progress state for streaming updates. */
-  emitPartial(): void {
+  /**
+   * Export a span's in-progress state for streaming updates. Defaults to the
+   * current active span; pass an explicit span to snapshot one that is not
+   * active (e.g. a long-lived root opened with `startSpan`).
+   */
+  emitPartial(span?: ApiSpan): void {
     dontThrow("JudgmentSpanProcessor.emitPartial", () => {
-      const span = getTraceRuntime().getCurrentSpan();
-      if (!span?.isRecording()) return;
-      const ctx = span.spanContext();
+      const target = span ?? getTraceRuntime().getCurrentSpan();
+      if (!target?.isRecording()) return;
+      const ctx = target.spanContext();
       if (!ctx.traceId) return;
       if (
         this.stateGet<boolean>(
@@ -168,7 +173,7 @@ export class JudgmentSpanProcessor extends BatchSpanProcessor {
       ) {
         return;
       }
-      this._emitSpan(span as unknown as ReadableSpan, true);
+      this._emitSpan(target as unknown as ReadableSpan, true);
     });
   }
 

--- a/src/trace/processors/NoOpSpanProcessor.ts
+++ b/src/trace/processors/NoOpSpanProcessor.ts
@@ -1,4 +1,4 @@
-import type { Context, SpanContext } from "@opentelemetry/api";
+import type { Context, Span as ApiSpan, SpanContext } from "@opentelemetry/api";
 import type { ReadableSpan, Span } from "@opentelemetry/sdk-trace-base";
 import { NoOpSpanExporter } from "../exporters/NoOpSpanExporter";
 import { JudgmentSpanProcessor } from "./JudgmentSpanProcessor";
@@ -29,7 +29,7 @@ export class NoOpSpanProcessor extends JudgmentSpanProcessor {
     return Promise.resolve();
   }
 
-  emitPartial(): void {
+  emitPartial(_span?: ApiSpan): void {
     /* empty */
   }
 


### PR DESCRIPTION
## Summary

The live span processor could only partial-emit the *active* span (via the private `_emitPartial`, used by `observe`/`with`/`startActiveSpan`). A long-lived span opened with `startSpan` and held across invocations — e.g. an agent "run" root driven by a durable step loop — had no way to reach the backend before it ends, so an eviction or early failure would orphan its children.

This exposes a public `Tracer.emitPartial(span?)` that snapshots an explicit span (defaulting to the active one) through `JudgmentSpanProcessor.emitPartial(span?)`. The backend already merges re-emissions of a span by update id, so the span can be emitted early (input only) and upgraded with output + true duration when it finally ends. `_emitPartial` now delegates to the public method.

Minor bump → **1.3.0** (additive, backward-compatible API).

### Why this is needed (the consumer)

[JudgmentLabs/luna#82](https://github.com/JudgmentLabs/luna/pull/82) instruments the Cloudflare agent harness with Judgment tracing. Its `luna.agent.run` root span spans many **durable steps that run as separate invocations**, with possible mid-run eviction — so the root can't be the active span, yet it must reach the backend up front (or eviction orphans its child spans) and still carry the run's output when it ends. `emitPartial(span)` is the only public way to snapshot that held-open, non-active root; there is no other entrypoint for it today. luna#82 is blocked on this PR publishing 1.3.0.

## Testing

- `bun run check` (tsc + oxlint) — clean.
- `bun test` — 106 pass, including new `src/trace/processors/JudgmentSpanProcessor.test.ts`:
  - `emitPartial(span)` snapshots a non-active span as a partial (zero-duration snapshot, update id 0), asserting the full exported span content;
  - ending the span after a partial re-emits it with a higher update id and the added output (the upgrade path).
- `bun scripts/build.ts` — `static emitPartial(span?: Span)` present in the built `dist/.../BaseTracer.d.ts`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/judgmentlabs/judgeval-js/pull/68" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
