### PR TITLE
JUD-7651: ignore leading/trailing whitespace on PR body section headings

### DIFF
--- a/.github/workflows/pr-body-check.yaml
+++ b/.github/workflows/pr-body-check.yaml
@@ -35,7 +35,7 @@ jobs:
 
           def section(name):
               pattern = re.compile(
-                  r"^#{1,6}[ \t]+" + re.escape(name) + r"[ \t]*$(.*?)(?=^##[ \t]|\Z)",
+                  r"^[ \t]*#{1,6}[ \t]+" + re.escape(name) + r"[ \t]*$(.*?)(?=^[ \t]*##[ \t]|\Z)",
                   re.IGNORECASE | re.MULTILINE | re.DOTALL,
               )
               m = pattern.search(body)


### PR DESCRIPTION
## Summary

Ports the judgment-mono fix to this repo. The `required-sections` PR body check anchored heading matching on `^#{1,6}`, so any leading whitespace before a `## Summary` / `## Testing` heading caused the regex to miss it. Bodies generated by tools that indent content failed the check even when the sections were present and filled out.

- Heading match: `^#{1,6}` -> `^[ \t]*#{1,6}`
- Section terminator lookahead: `(?=^##[ \t]` -> `(?=^[ \t]*##[ \t]`, so an indented next heading still ends the prior section.

Trailing whitespace was already handled by `[ \t]*$`.

## Testing

Validator regex change verified against an indented `## Testing` heading in judgment-mono (#2719): before, exit 1 "Missing required section"; after, both sections detected, exit 0. This change is identical.

Closes JUD-7651
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/judgmentlabs/judgeval-js/pull/69" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->