### PR TITLE
JUD-7824 feat(trace): public setPropagatingAttribute (parity with Python SDK)

### DIFF
--- a/src/trace/BaseTracer.propagation.test.ts
+++ b/src/trace/BaseTracer.propagation.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, spyOn, test } from "bun:test";
+import {
+  BasicTracerProvider,
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from "@opentelemetry/sdk-trace-base";
+import { JudgmentTracerProvider } from "./JudgmentTracerProvider";
+import { BaseTracer } from "./BaseTracer";
+import { JudgmentBaggageSpanProcessor } from "./processors/JudgmentBaggageSpanProcessor";
+import { NoOpSpanExporter } from "./exporters/NoOpSpanExporter";
+import { NoOpSpanProcessor } from "./processors/NoOpSpanProcessor";
+import { Logger } from "../utils/logger";
+import { AttributeKeys } from "../JudgmentAttributeKeys";
+import type { JudgmentSpanExporter } from "./exporters/JudgmentSpanExporter";
+import type { JudgmentSpanProcessor } from "./processors/JudgmentSpanProcessor";
+
+class FakeTracer extends BaseTracer {
+  constructor(provider: BasicTracerProvider) {
+    super(
+      "test-project",
+      "test-project-id",
+      "test-key",
+      "test-org",
+      "https://example.com",
+      null,
+      (v) => String(v),
+      provider,
+      null,
+      false,
+    );
+  }
+
+  getSpanProcessor(): JudgmentSpanProcessor {
+    return new NoOpSpanProcessor() as unknown as JudgmentSpanProcessor;
+  }
+
+  getSpanExporter(): JudgmentSpanExporter {
+    return new NoOpSpanExporter();
+  }
+}
+
+function setupProxy(): {
+  proxy: JudgmentTracerProvider;
+  exporter: InMemorySpanExporter;
+  cleanup: () => void;
+} {
+  const exporter = new InMemorySpanExporter();
+  // Wire the baggage processor so propagating attributes land on child spans,
+  // mirroring the real tracer pipeline.
+  const sdkProvider = new BasicTracerProvider({
+    spanProcessors: [
+      new JudgmentBaggageSpanProcessor(),
+      new SimpleSpanProcessor(exporter),
+    ],
+  });
+  const tracer = new FakeTracer(sdkProvider);
+  const proxy = JudgmentTracerProvider.getInstance();
+  proxy.register(tracer);
+  proxy.setActive(tracer);
+  return {
+    proxy,
+    exporter,
+    cleanup: () => {
+      proxy.deregister(tracer);
+    },
+  };
+}
+
+describe("BaseTracer.setPropagatingAttribute", () => {
+  test("sets the attribute on the current span", () => {
+    const { exporter, cleanup } = setupProxy();
+    try {
+      BaseTracer.span("surface", () => {
+        BaseTracer.setPropagatingAttribute("luna.surface", "slack");
+      });
+      const span = exporter
+        .getFinishedSpans()
+        .find((s) => s.name === "surface");
+      expect(span?.attributes["luna.surface"]).toBe("slack");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("propagates the attribute to child spans via baggage", () => {
+    const { exporter, cleanup } = setupProxy();
+    try {
+      BaseTracer.span("root", () => {
+        BaseTracer.setPropagatingAttribute("luna.surface", "platform");
+        BaseTracer.span("child", () => {});
+      });
+      const child = exporter.getFinishedSpans().find((s) => s.name === "child");
+      expect(child?.attributes["luna.surface"]).toBe("platform");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("rejects keys using the reserved judgment. prefix", () => {
+    const { exporter, cleanup } = setupProxy();
+    const errorSpy = spyOn(Logger, "error");
+    try {
+      BaseTracer.span("reserved", () => {
+        BaseTracer.setPropagatingAttribute(
+          AttributeKeys.JUDGMENT_CUSTOMER_ID,
+          "evil",
+        );
+      });
+      const span = exporter
+        .getFinishedSpans()
+        .find((s) => s.name === "reserved");
+      expect(span?.attributes[AttributeKeys.JUDGMENT_CUSTOMER_ID]).toBeUndefined();
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      errorSpy.mockRestore();
+      cleanup();
+    }
+  });
+});

--- a/src/trace/BaseTracer.ts
+++ b/src/trace/BaseTracer.ts
@@ -1008,20 +1008,10 @@ export abstract class BaseTracer {
   }
 
   /**
-   * Set an arbitrary attribute on the current active span and propagate it
-   * to all child spans via baggage.
+   * Set an attribute and propagate it to all child spans via baggage.
    *
-   * Unlike {@link setAttribute}, which applies only to a single span, the
-   * value set here follows the whole trace — every descendant span receives
-   * it as an attribute. Use this to tag a trace with a dimension you want to
-   * filter on in Views (e.g. the surface an agent is running on).
-   *
-   * The `judgment.` namespace is reserved for SDK-managed keys (customer ID,
-   * session ID, etc.); use {@link setCustomerId} / {@link setSessionId} for
-   * those instead.
-   *
-   * @param key - The attribute key. Must not use the reserved `judgment.` prefix.
-   * @param value - The attribute value.
+   * Unlike {@link setAttribute} (single span only). The `judgment.` prefix is
+   * reserved and ignored.
    */
   static setPropagatingAttribute(key: string, value: string): void {
     if (key.startsWith("judgment.")) {

--- a/src/trace/BaseTracer.ts
+++ b/src/trace/BaseTracer.ts
@@ -1007,6 +1007,32 @@ export abstract class BaseTracer {
     );
   }
 
+  /**
+   * Set an arbitrary attribute on the current active span and propagate it
+   * to all child spans via baggage.
+   *
+   * Unlike {@link setAttribute}, which applies only to a single span, the
+   * value set here follows the whole trace — every descendant span receives
+   * it as an attribute. Use this to tag a trace with a dimension you want to
+   * filter on in Views (e.g. the surface an agent is running on).
+   *
+   * The `judgment.` namespace is reserved for SDK-managed keys (customer ID,
+   * session ID, etc.); use {@link setCustomerId} / {@link setSessionId} for
+   * those instead.
+   *
+   * @param key - The attribute key. Must not use the reserved `judgment.` prefix.
+   * @param value - The attribute value.
+   */
+  static setPropagatingAttribute(key: string, value: string): void {
+    if (key.startsWith("judgment.")) {
+      Logger.error(
+        `setPropagatingAttribute: key "${key}" uses the reserved "judgment." prefix; ignoring`,
+      );
+      return;
+    }
+    BaseTracer._setPropagatingBaggageKey(key, value);
+  }
+
   // ------------------------------------------------------------------ //
   //  Static: Tags                                                      //
   // ------------------------------------------------------------------ //


### PR DESCRIPTION
## Summary
TS-SDK counterpart to JudgmentLabs/judgeval#753. Adds `Tracer.setPropagatingAttribute(key, value)` — a public wrapper over the existing private `_setPropagatingBaggageKey`. Sets the value on the current span **and** in OTel baggage, so it propagates to every child span, exactly like `setCustomerId` / `setSessionId`. Guards the reserved `judgment.` namespace.

Unlike `setAttribute` (single-span only), this follows the whole trace — for tagging a trace with a filterable dimension (e.g. the surface an agent runs on).

## Testing
New `BaseTracer.propagation.test.ts` wires the real `JudgmentBaggageSpanProcessor` so child propagation is actually exercised: sets-on-span, propagates-to-child, rejects-reserved-prefix. `tsc` + `oxlint` + `bun test` green.

## Follow-ups (depend on this being published)
- luna harness: set `luna.surface` on the agent run's root span
- judgment-mono: send `surface` to the harness

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/judgmentlabs/judgeval-js/pull/71" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->