### PR TITLE
Harden npm package manifest validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,8 @@ jobs:
       - run: bun run build
       - name: Check generated JQL output is current
         run: git diff --exit-code -- src/jql
+      - name: Check package contents with canonical checkout present
+        run: bun run check-package
 
       - name: Get version from package.json
         id: pkg
@@ -92,6 +94,9 @@ jobs:
       - run: bun install
       - run: bun run check
       - run: bun run build
+
+      - name: Check package contents
+        run: bun run check-package
 
       - name: Publish to npm
         run: npm publish --provenance --access public

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -31,8 +31,7 @@ jobs:
 
       - name: Check package contents
         run: |
-          mkdir -p .jql-source/judgment-mono
-          echo "PRIVATE MONOREPO CONTENT" > .jql-source/judgment-mono/PRIVATE_SOURCE_MARKER
+          bun run check-package --plant
           bun run check-package
 
       - name: Check build output

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -29,8 +29,11 @@ jobs:
       - name: Check generated JQL output is current
         run: git diff --exit-code -- src/jql
 
-      - name: Dry run publish
-        run: npm publish --dry-run --access public
+      - name: Check package contents
+        run: |
+          mkdir -p .jql-source/judgment-mono
+          echo "PRIVATE MONOREPO CONTENT" > .jql-source/judgment-mono/PRIVATE_SOURCE_MARKER
+          bun run check-package
 
       - name: Check build output
         run: |
@@ -75,3 +78,9 @@ jobs:
 
       - name: Check canonical JQL parity
         run: git diff --exit-code -- src/jql
+
+      - name: Build package
+        run: bun run build
+
+      - name: Check package contents with canonical checkout present
+        run: bun run check-package

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ yarn-error.log*
 
 dist/
 dist-examples/
+.jql-source/
+*.tgz
 # env files (can opt-in for committing if needed)
 .env*
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "build": "bun run generate-jql && bun run check && bun scripts/build.ts",
     "build:dev": "bun scripts/build.ts --dev",
     "check": "tsc --noEmit && oxlint src/",
+    "check-package": "bun scripts/check-package-contents.ts",
     "lint": "oxlint src/",
     "lint:fix": "oxlint --fix src/",
     "format": "prettier --write \"src/**/*.ts\"",

--- a/scripts/check-package-contents.test.ts
+++ b/scripts/check-package-contents.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import {
+  expectedPackageFiles,
+  manifestErrors,
+  type PackFile,
+  type PackResult,
+} from "./check-package-contents";
+
+const tracked = ["README.md", "src/index.ts", "src/example.test.ts"];
+const expected = expectedPackageFiles(tracked);
+
+function pack(paths: string[]): PackResult {
+  const files: PackFile[] = paths.map((path) => ({
+    path,
+    size: 1,
+    mode: 0o644,
+  }));
+  return {
+    filename: "judgeval-1.0.0.tgz",
+    size: files.length,
+    unpackedSize: files.length,
+    entryCount: files.length,
+    files,
+  };
+}
+
+describe("package manifest validation", () => {
+  test("derives declarations from tracked runtime sources", () => {
+    expect(expected.has("dist/index.d.ts")).toBe(true);
+    expect(expected.has("dist/index.d.ts.map")).toBe(true);
+    expect(expected.has("dist/example.test.d.ts")).toBe(false);
+  });
+
+  test("rejects extra files even under dist", () => {
+    const result = pack([...expected, "dist/private-source.d.ts"]);
+
+    expect(manifestErrors(result, expected)).toEqual([
+      "unexpected files: dist/private-source.d.ts",
+    ]);
+  });
+
+  test("rejects missing expected files", () => {
+    const [missing, ...paths] = [...expected];
+
+    expect(manifestErrors(pack(paths), expected)).toEqual([
+      `missing files: ${missing}`,
+    ]);
+  });
+});

--- a/scripts/check-package-contents.test.ts
+++ b/scripts/check-package-contents.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, test } from "bun:test";
 import {
   expectedPackageFiles,
   manifestErrors,
-  type PackFile,
   type PackResult,
 } from "./check-package-contents";
 
@@ -10,11 +9,7 @@ const tracked = ["README.md", "src/index.ts", "src/example.test.ts"];
 const expected = expectedPackageFiles(tracked);
 
 function pack(paths: string[]): PackResult {
-  const files: PackFile[] = paths.map((path) => ({
-    path,
-    size: 1,
-    mode: 0o644,
-  }));
+  const files = paths.map((path) => ({ path }));
   return {
     filename: "judgeval-1.0.0.tgz",
     size: files.length,
@@ -25,10 +20,28 @@ function pack(paths: string[]): PackResult {
 }
 
 describe("package manifest validation", () => {
-  test("derives declarations from tracked runtime sources", () => {
-    expect(expected.has("dist/index.d.ts")).toBe(true);
-    expect(expected.has("dist/index.d.ts.map")).toBe(true);
-    expect(expected.has("dist/example.test.d.ts")).toBe(false);
+  test("derives the full manifest from tracked paths", () => {
+    expect(expected).toEqual(
+      new Set([
+        "package.json",
+        "README.md",
+        "dist/index.d.ts",
+        "dist/index.d.ts.map",
+        "dist/node/index.cjs",
+        "dist/node/index.cjs.map",
+        "dist/node/index.d.ts",
+        "dist/node/index.mjs",
+        "dist/node/index.mjs.map",
+        "dist/node/jql.cjs",
+        "dist/node/jql.cjs.map",
+        "dist/node/jql.mjs",
+        "dist/node/jql.mjs.map",
+        "dist/workers/index.mjs",
+        "dist/workers/index.mjs.map",
+        "dist/workers/jql.mjs",
+        "dist/workers/jql.mjs.map",
+      ]),
+    );
   });
 
   test("rejects extra files even under dist", () => {
@@ -40,10 +53,16 @@ describe("package manifest validation", () => {
   });
 
   test("rejects missing expected files", () => {
-    const [missing, ...paths] = [...expected];
+    const paths = [...expected].filter((path) => path !== "package.json");
 
     expect(manifestErrors(pack(paths), expected)).toEqual([
-      `missing files: ${missing}`,
+      "missing files: package.json",
     ]);
+  });
+
+  test("rejects duplicate pack entries", () => {
+    expect(
+      manifestErrors(pack([...expected, "package.json"]), expected),
+    ).toEqual(["pack manifest contains duplicate or inconsistent entries"]);
   });
 });

--- a/scripts/check-package-contents.ts
+++ b/scripts/check-package-contents.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env bun
 
-import { unlink } from "fs/promises";
+import { mkdirSync, unlinkSync, writeFileSync } from "node:fs";
 
-export const PRIVATE_SOURCE_MARKER = "PRIVATE MONOREPO CONTENT";
-export const MAX_ARCHIVE_FILES = 1_000;
-export const MAX_ARCHIVE_BYTES = 5 * 1024 * 1024;
-export const MAX_UNPACKED_BYTES = 10 * 1024 * 1024;
+const PRIVATE_SOURCE_MARKER = "PRIVATE MONOREPO CONTENT";
+const MAX_ARCHIVE_FILES = 1_000;
+const MAX_ARCHIVE_BYTES = 5 * 1024 * 1024;
+const MAX_UNPACKED_BYTES = 10 * 1024 * 1024;
 
 const BUNDLE_FILES = new Set([
   "dist/node/index.cjs",
@@ -23,29 +23,22 @@ const BUNDLE_FILES = new Set([
   "dist/workers/jql.mjs.map",
 ]);
 
-export interface PackFile {
-  path: string;
-  size: number;
-  mode: number;
-}
-
 export interface PackResult {
   filename: string;
   size: number;
   unpackedSize: number;
   entryCount: number;
-  files: PackFile[];
+  files: { path: string }[];
 }
 
 export function expectedPackageFiles(trackedPaths: string[]): Set<string> {
   const expected = new Set(["package.json", ...BUNDLE_FILES]);
   for (const path of trackedPaths) {
-    if (["README.md", "LICENSE", "LICENSE.md"].includes(path)) {
+    if (!path.startsWith("src/")) {
       expected.add(path);
       continue;
     }
     if (
-      !path.startsWith("src/") ||
       !path.endsWith(".ts") ||
       path.endsWith(".d.ts") ||
       path.endsWith(".test.ts")
@@ -113,47 +106,41 @@ function trackedPaths(): string[] {
   return result.stdout.toString().split("\0").filter(Boolean);
 }
 
-async function packPackage(): Promise<PackResult> {
-  const process = Bun.spawn(["npm", "pack", "--json", "--ignore-scripts"], {
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([
-    new Response(process.stdout).text(),
-    new Response(process.stderr).text(),
-    process.exited,
-  ]);
-  if (exitCode !== 0) {
-    throw new Error(`npm pack failed: ${stderr}`);
+function packPackage(): PackResult {
+  const result = Bun.spawnSync(["npm", "pack", "--json", "--ignore-scripts"]);
+  if (result.exitCode !== 0) {
+    throw new Error(`npm pack failed: ${result.stderr.toString()}`);
   }
-  const results = JSON.parse(stdout) as PackResult[];
+  const results = JSON.parse(result.stdout.toString()) as PackResult[];
   if (results.length !== 1) {
     throw new Error(`expected one packed artifact, found ${results.length}`);
   }
   return results[0];
 }
 
-async function archiveContainsMarker(filename: string): Promise<boolean> {
-  const process = Bun.spawn(["tar", "-xOzf", filename], {
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [contents, stderr, exitCode] = await Promise.all([
-    new Response(process.stdout).text(),
-    new Response(process.stderr).text(),
-    process.exited,
-  ]);
-  if (exitCode !== 0) {
-    throw new Error(`could not inspect ${filename}: ${stderr}`);
+function archiveContainsMarker(filename: string): boolean {
+  const result = Bun.spawnSync(["tar", "-xOzf", filename]);
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `could not inspect ${filename}: ${result.stderr.toString()}`,
+    );
   }
-  return contents.includes(PRIVATE_SOURCE_MARKER);
+  return result.stdout.toString().includes(PRIVATE_SOURCE_MARKER);
 }
 
-async function main(): Promise<void> {
-  const pack = await packPackage();
+function plantMarker(): void {
+  mkdirSync(".jql-source/judgment-mono", { recursive: true });
+  writeFileSync(
+    ".jql-source/judgment-mono/PRIVATE_SOURCE_MARKER",
+    PRIVATE_SOURCE_MARKER,
+  );
+}
+
+function main(): void {
+  const pack = packPackage();
   try {
     const errors = manifestErrors(pack, expectedPackageFiles(trackedPaths()));
-    if (await archiveContainsMarker(pack.filename)) {
+    if (archiveContainsMarker(pack.filename)) {
       errors.push("private-source marker found in packed file contents");
     }
     if (errors.length > 0) {
@@ -163,10 +150,14 @@ async function main(): Promise<void> {
       `Validated ${pack.filename}: ${pack.entryCount} files, ${pack.unpackedSize} unpacked bytes.`,
     );
   } finally {
-    await unlink(pack.filename);
+    unlinkSync(pack.filename);
   }
 }
 
 if (import.meta.main) {
-  await main();
+  if (process.argv.includes("--plant")) {
+    plantMarker();
+  } else {
+    main();
+  }
 }

--- a/scripts/check-package-contents.ts
+++ b/scripts/check-package-contents.ts
@@ -1,0 +1,172 @@
+#!/usr/bin/env bun
+
+import { unlink } from "fs/promises";
+
+export const PRIVATE_SOURCE_MARKER = "PRIVATE MONOREPO CONTENT";
+export const MAX_ARCHIVE_FILES = 1_000;
+export const MAX_ARCHIVE_BYTES = 5 * 1024 * 1024;
+export const MAX_UNPACKED_BYTES = 10 * 1024 * 1024;
+
+const BUNDLE_FILES = new Set([
+  "dist/node/index.cjs",
+  "dist/node/index.cjs.map",
+  "dist/node/index.d.ts",
+  "dist/node/index.mjs",
+  "dist/node/index.mjs.map",
+  "dist/node/jql.cjs",
+  "dist/node/jql.cjs.map",
+  "dist/node/jql.mjs",
+  "dist/node/jql.mjs.map",
+  "dist/workers/index.mjs",
+  "dist/workers/index.mjs.map",
+  "dist/workers/jql.mjs",
+  "dist/workers/jql.mjs.map",
+]);
+
+export interface PackFile {
+  path: string;
+  size: number;
+  mode: number;
+}
+
+export interface PackResult {
+  filename: string;
+  size: number;
+  unpackedSize: number;
+  entryCount: number;
+  files: PackFile[];
+}
+
+export function expectedPackageFiles(trackedPaths: string[]): Set<string> {
+  const expected = new Set(["package.json", ...BUNDLE_FILES]);
+  for (const path of trackedPaths) {
+    if (["README.md", "LICENSE", "LICENSE.md"].includes(path)) {
+      expected.add(path);
+      continue;
+    }
+    if (
+      !path.startsWith("src/") ||
+      !path.endsWith(".ts") ||
+      path.endsWith(".d.ts") ||
+      path.endsWith(".test.ts")
+    ) {
+      continue;
+    }
+    const declaration = `dist/${path.slice("src/".length, -".ts".length)}.d.ts`;
+    expected.add(declaration);
+    expected.add(`${declaration}.map`);
+  }
+  return expected;
+}
+
+export function manifestErrors(
+  pack: PackResult,
+  expected: Set<string>,
+): string[] {
+  const paths = new Set(pack.files.map((file) => file.path));
+  const errors: string[] = [];
+  const unexpected = [...paths].filter((path) => !expected.has(path)).sort();
+  const missing = [...expected].filter((path) => !paths.has(path)).sort();
+
+  if (unexpected.length > 0) {
+    errors.push(`unexpected files: ${unexpected.join(", ")}`);
+  }
+  if (missing.length > 0) {
+    errors.push(`missing files: ${missing.join(", ")}`);
+  }
+  if (
+    paths.size !== pack.files.length ||
+    pack.entryCount !== pack.files.length
+  ) {
+    errors.push("pack manifest contains duplicate or inconsistent entries");
+  }
+  if (pack.entryCount > MAX_ARCHIVE_FILES) {
+    errors.push(
+      `contains ${pack.entryCount} files; limit is ${MAX_ARCHIVE_FILES}`,
+    );
+  }
+  if (pack.size > MAX_ARCHIVE_BYTES) {
+    errors.push(`archive is ${pack.size} bytes; limit is ${MAX_ARCHIVE_BYTES}`);
+  }
+  if (pack.unpackedSize > MAX_UNPACKED_BYTES) {
+    errors.push(
+      `unpacked size is ${pack.unpackedSize} bytes; limit is ${MAX_UNPACKED_BYTES}`,
+    );
+  }
+  return errors;
+}
+
+function trackedPaths(): string[] {
+  const result = Bun.spawnSync([
+    "git",
+    "ls-files",
+    "-z",
+    "--",
+    "src",
+    "README.md",
+    "LICENSE",
+    "LICENSE.md",
+  ]);
+  if (result.exitCode !== 0) {
+    throw new Error(result.stderr.toString());
+  }
+  return result.stdout.toString().split("\0").filter(Boolean);
+}
+
+async function packPackage(): Promise<PackResult> {
+  const process = Bun.spawn(["npm", "pack", "--json", "--ignore-scripts"], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(process.stdout).text(),
+    new Response(process.stderr).text(),
+    process.exited,
+  ]);
+  if (exitCode !== 0) {
+    throw new Error(`npm pack failed: ${stderr}`);
+  }
+  const results = JSON.parse(stdout) as PackResult[];
+  if (results.length !== 1) {
+    throw new Error(`expected one packed artifact, found ${results.length}`);
+  }
+  return results[0];
+}
+
+async function archiveContainsMarker(filename: string): Promise<boolean> {
+  const process = Bun.spawn(["tar", "-xOzf", filename], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [contents, stderr, exitCode] = await Promise.all([
+    new Response(process.stdout).text(),
+    new Response(process.stderr).text(),
+    process.exited,
+  ]);
+  if (exitCode !== 0) {
+    throw new Error(`could not inspect ${filename}: ${stderr}`);
+  }
+  return contents.includes(PRIVATE_SOURCE_MARKER);
+}
+
+async function main(): Promise<void> {
+  const pack = await packPackage();
+  try {
+    const errors = manifestErrors(pack, expectedPackageFiles(trackedPaths()));
+    if (await archiveContainsMarker(pack.filename)) {
+      errors.push("private-source marker found in packed file contents");
+    }
+    if (errors.length > 0) {
+      throw new Error(`Invalid npm package contents:\n${errors.join("\n")}`);
+    }
+    console.log(
+      `Validated ${pack.filename}: ${pack.entryCount} files, ${pack.unpackedSize} unpacked bytes.`,
+    );
+  } finally {
+    await unlink(pack.filename);
+  }
+}
+
+if (import.meta.main) {
+  await main();
+}


### PR DESCRIPTION
## Summary

- add an exact npm package manifest check based on tracked runtime sources and expected build outputs
- reject unexpected or missing files, duplicate/inconsistent entries, oversized artifacts, and a private-source content marker
- run the check in PR validation, with the canonical monorepo checkout present, and immediately before npm publish
- add focused tests proving that extra files under `dist/` are rejected

## Why

`package.json#files` limited publishing to `dist/**/*`, `README.md`, and `LICENSE`, but `npm publish --dry-run` only reported what would ship; it did not assert that the file list was expected. Anything accidentally copied under `dist/` could therefore be published.

This change turns the dry run into an exact, failing allow-list check.

## Testing

- `bunx prettier --check scripts/check-package-contents.ts scripts/check-package-contents.test.ts package.json .github/workflows/release.yml .github/workflows/test-install.yml`
- `bun run check`
- `bun test` — 113 passed
- `bun run build`
- `bun run check-package`
- adversarial local check confirmed `dist/private-source.d.ts` is rejected
