### PR TITLE
Release judgeval 1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "judgeval",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "JavaScript/TypeScript client for Judgment evaluation platform",
   "main": "./dist/node/index.cjs",
   "module": "./dist/node/index.mjs",


### PR DESCRIPTION
## Summary

Bump the TypeScript Judgeval SDK from `1.2.1` to `1.3.0` so the merged public JQL API can be published to npm.

This is a minor release because it adds the backward-compatible `judgeval/jql` entry point and `Judgeval.query()`, `Judgeval.present()`, and `Judgeval.discover()` methods.

## Release behavior

After this PR merges, the release workflow will verify canonical JQL parity, build the package, create tag `v1.3.0`, publish `judgeval@1.3.0` to npm with provenance, and create the GitHub release.

Package-hardening PR #73 should merge before this PR so its exact package-content validation runs during publication.

## Testing

- `bun install --frozen-lockfile`
- `bun test` — 110 passed
- `bun run build`
- `git diff --check`