### PR TITLE
Configure Worker span batching

### DIFF
--- a/src/trace/processors/JudgmentSpanProcessor.ts
+++ b/src/trace/processors/JudgmentSpanProcessor.ts
@@ -21,6 +21,17 @@ import { JudgmentBaggageSpanProcessor } from "./JudgmentBaggageSpanProcessor";
 
 type SpanKey = `${string}:${string}`;
 
+export interface JudgmentSpanProcessorConfig {
+  /** Maximum number of spans exported in one batch. Defaults to 512. */
+  maxExportBatchSize?: number;
+  /** Delay between scheduled exports in milliseconds. Defaults to 5000. */
+  scheduledDelayMillis?: number;
+  /** Maximum export duration in milliseconds. Defaults to 30000. */
+  exportTimeoutMillis?: number;
+  /** Maximum number of queued spans before new spans are dropped. Defaults to 2048. */
+  maxQueueSize?: number;
+}
+
 function makeSpanKey(ctx: SpanContext): SpanKey {
   return `${ctx.traceId}:${ctx.spanId}`;
 }
@@ -47,12 +58,7 @@ export class JudgmentSpanProcessor extends BatchSpanProcessor {
   constructor(
     tracer: BaseTracer | null,
     exporter: SpanExporter,
-    config?: {
-      maxQueueSize?: number;
-      scheduledDelayMillis?: number;
-      maxExportBatchSize?: number;
-      exportTimeoutMillis?: number;
-    },
+    config?: JudgmentSpanProcessorConfig,
   ) {
     super(exporter, config);
     this.tracer = tracer;

--- a/src/workers/Tracer.test.ts
+++ b/src/workers/Tracer.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { Tracer, type JudgmentSpanProcessorConfig } from "./index";
+import { WorkerTracerProvider } from "./WorkerTracerProvider";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(async () => {
+  globalThis.fetch = originalFetch;
+  await WorkerTracerProvider.getInstance().shutdown();
+});
+
+function timeoutAfter(milliseconds: number): Promise<never> {
+  return new Promise((_, reject) => {
+    setTimeout(() => {
+      reject(new Error("timed out waiting for span export"));
+    }, milliseconds);
+  });
+}
+
+describe("Workers Tracer span processor configuration", () => {
+  test("forwards batch settings to JudgmentSpanProcessor", async () => {
+    let markExported = (): void => {};
+    const exported = new Promise<void>((resolve) => {
+      markExported = resolve;
+    });
+    globalThis.fetch = Object.assign(
+      () => {
+        markExported();
+        return Promise.resolve(new Response(null, { status: 200 }));
+      },
+      { preconnect: originalFetch.preconnect },
+    );
+
+    const spanProcessorConfig: JudgmentSpanProcessorConfig = {
+      maxQueueSize: 1,
+      maxExportBatchSize: 1,
+      scheduledDelayMillis: 60_000,
+    };
+    const tracer = await Tracer.init({
+      apiKey: "test-api-key",
+      organizationId: "test-organization-id",
+      projectId: "test-project-id",
+      apiUrl: "https://example.com",
+      setActive: false,
+      spanProcessorConfig,
+    });
+
+    const span = tracer._tracerProvider.getTracer("test").startSpan("test");
+    span.end();
+
+    await expect(
+      Promise.race([exported, timeoutAfter(1_000)]),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/workers/Tracer.ts
+++ b/src/workers/Tracer.ts
@@ -10,7 +10,10 @@ import { VERSION } from "../version";
 import { BaseTracer, type TracerConfig } from "../trace/BaseTracer";
 import type { SpanExporter } from "@opentelemetry/sdk-trace-base";
 import type { JudgmentSpanExporter } from "../trace/exporters/JudgmentSpanExporter";
-import { JudgmentSpanProcessor } from "../trace/processors/JudgmentSpanProcessor";
+import {
+  JudgmentSpanProcessor,
+  type JudgmentSpanProcessorConfig,
+} from "../trace/processors/JudgmentSpanProcessor";
 import { WorkerTracerProvider } from "./WorkerTracerProvider";
 import { WorkerSpanExporter } from "./WorkerSpanExporter";
 
@@ -28,6 +31,8 @@ export interface WorkersTracerConfig extends Omit<
   organizationId: string;
   /** Judgment API URL. Required; Workers do not read process.env. */
   apiUrl: string;
+  /** Configuration for Judgment's built-in batch span processor. */
+  spanProcessorConfig?: JudgmentSpanProcessorConfig;
 }
 
 function requireConfigValue(value: string | undefined, key: string): string {
@@ -40,6 +45,9 @@ function requireConfigValue(value: string | undefined, key: string): string {
 export class Tracer extends BaseTracer {
   private _spanExporter: SpanExporter | null = null;
   private _spanProcessor: JudgmentSpanProcessor | null = null;
+  private readonly _spanProcessorConfig:
+    | JudgmentSpanProcessorConfig
+    | undefined;
 
   protected constructor(
     projectName: string | null,
@@ -51,6 +59,7 @@ export class Tracer extends BaseTracer {
     serializer: (v: unknown) => string,
     tracerProvider: WebTracerProvider,
     client: JudgmentApiClient,
+    spanProcessorConfig: JudgmentSpanProcessorConfig | undefined,
   ) {
     super(
       projectName,
@@ -64,6 +73,7 @@ export class Tracer extends BaseTracer {
       client,
       true,
     );
+    this._spanProcessorConfig = spanProcessorConfig;
   }
 
   static async init(config: WorkersTracerConfig): Promise<Tracer> {
@@ -120,6 +130,7 @@ export class Tracer extends BaseTracer {
         spanLimits: config.spanLimits,
       }),
       client,
+      config.spanProcessorConfig,
     );
 
     const providerWithProcessor = new WebTracerProvider({
@@ -164,6 +175,7 @@ export class Tracer extends BaseTracer {
     this._spanProcessor = new JudgmentSpanProcessor(
       this,
       this.getSpanExporter(),
+      this._spanProcessorConfig,
     );
     return this._spanProcessor;
   }

--- a/src/workers/index.ts
+++ b/src/workers/index.ts
@@ -8,7 +8,10 @@ export {
 export { Tracer, type WorkersTracerConfig } from "./Tracer";
 export { wrap, wrapOpenAI } from "../instrumentation";
 export { WorkerSpanExporter } from "./WorkerSpanExporter";
-export { JudgmentSpanProcessor } from "../trace/processors/JudgmentSpanProcessor";
+export {
+  JudgmentSpanProcessor,
+  type JudgmentSpanProcessorConfig,
+} from "../trace/processors/JudgmentSpanProcessor";
 export {
   ALLOW_ALL_BAGGAGE_KEYS,
   JudgmentBaggageSpanProcessor,


### PR DESCRIPTION
## Summary

- expose a typed `JudgmentSpanProcessorConfig` for the built-in batch processor
- allow `judgeval/workers` callers to provide that config through `Tracer.init()`
- forward the configuration to the Worker `JudgmentSpanProcessor`
- export the config type from the Workers entrypoint

## Why

Cloudflare Worker consumers currently cannot tune Judgeval's fixed batch queue through `Tracer.init()`. High-concurrency isolates therefore have no way to trade queue capacity, export batch size, scheduled delay, and export timeout against checkpoint-level flushing.

This keeps the existing defaults unchanged while allowing runtimes such as Luna's shared-isolate tracer to configure the processor explicitly.

## Testing

- `bun run check`
- `bun test` (115 passing)
- `bun run build`
- added a Worker integration test proving `maxExportBatchSize: 1` triggers an immediate one-span export even with a 60-second scheduled delay
- built and packed commit `67aadef`, installed it into Luna's `rishi/tracing` worktree, and ran the Cloudflare harness stress test with `maxQueueSize: 16384`
- at 64 agents × 20 turns, both immediate and 250 ms collectors retained all 15,680 span records and all 7,872 unique spans with zero agent errors

The Luna run still produced 2,624 OTLP requests per case (peak concurrency 93 immediate / 550 delayed), confirming this API closes the observed queue-loss envelope but does not by itself coalesce checkpoint flushes.
