### PR TITLE
feat(jql): explain the opaque 404 from the public JQL API

### DIFF
--- a/src/Judgeval.ts
+++ b/src/Judgeval.ts
@@ -188,6 +188,7 @@ export class Judgeval {
       this._client.getApiKey(),
       this._client.getOrganizationId(),
       this._projectId,
+      this._projectName,
     );
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,7 @@ export {
   type PassConditionFn,
 } from "./offline-tests";
 
-export { JudgevalAPIError } from "./jql/client";
+export { JudgevalAPIError, JudgevalJqlUnavailableError } from "./jql/client";
 export type {
   JqlPresentationResponse,
   JqlQueryInput,

--- a/src/jql/client.ts
+++ b/src/jql/client.ts
@@ -31,6 +31,34 @@ export class JudgevalAPIError extends Error {
   }
 }
 
+/**
+ * Thrown when a JQL request is answered with HTTP 404.
+ *
+ * The public JQL API returns the same opaque 404 whether JQL is not enabled
+ * for the organization or the project does not exist, so this error covers
+ * both causes and its message names them. Distinct from a 503, which means
+ * JQL is enabled but temporarily unavailable.
+ */
+export class JudgevalJqlUnavailableError extends JudgevalAPIError {
+  constructor(
+    status: number,
+    code: string,
+    message: string,
+    hint = "",
+    retryAfterSeconds?: number,
+  ) {
+    super(status, code, message, hint, retryAfterSeconds);
+    this.name = "JudgevalJqlUnavailableError";
+  }
+}
+
+/**
+ * Message the API sends when a JQL-enabled organization asks for a project it
+ * cannot see. Used only to sharpen the 404 message; an unrecognized message
+ * falls back to naming both possible causes.
+ */
+const JQL_PROJECT_NOT_FOUND_MESSAGE = "Project not found";
+
 export type JqlQueryInput = Query | QueryBuilder | PipelineBuilder;
 
 function toQuery(input: JqlQueryInput): Query {
@@ -43,6 +71,7 @@ export class JudgevalJqlClient {
     private readonly apiKey: string,
     private readonly organizationId: string,
     private readonly projectId: string,
+    private readonly projectName?: string,
   ) {}
 
   query(
@@ -98,14 +127,41 @@ export class JudgevalJqlClient {
         // Preserve the response body below when the server did not return JSON.
       }
       const retryAfter = response.headers.get("Retry-After");
-      throw new JudgevalAPIError(
+      const ErrorType =
+        response.status === 404
+          ? JudgevalJqlUnavailableError
+          : JudgevalAPIError;
+      throw new ErrorType(
         response.status,
         payload.error ?? `HTTP_${response.status}`,
-        payload.message ?? text,
+        response.status === 404
+          ? this.unavailableMessage(payload.message)
+          : (payload.message ?? text),
         payload.hint ?? "",
         retryAfter === null ? undefined : Number(retryAfter),
       );
     }
     return JSON.parse(text) as T;
+  }
+
+  /**
+   * Explain the opaque 404 the public JQL API returns.
+   *
+   * The organization-level feature gate runs before the project lookup
+   * server-side, so a disabled organization never reaches the project check.
+   * That makes the two 404 messages disjoint: only a JQL-enabled organization
+   * can be told the project is missing. When the message is anything else,
+   * either cause is possible and both are named.
+   */
+  private unavailableMessage(serverMessage?: string): string {
+    const project = this.projectName ?? this.projectId;
+    if (serverMessage === JQL_PROJECT_NOT_FOUND_MESSAGE) {
+      return `Project '${project}' was not found for this organization.`;
+    }
+    return (
+      `JQL is not enabled for this organization, or project '${project}' was ` +
+      "not found — the API returns the same 404 for both. Contact Judgment to " +
+      "enable JQL for your organization."
+    );
   }
 }

--- a/src/jql/index.ts
+++ b/src/jql/index.ts
@@ -8,7 +8,7 @@ export type {
   TableQuery,
   TimeSpec,
 } from "./wire";
-export { JudgevalAPIError } from "./client";
+export { JudgevalAPIError, JudgevalJqlUnavailableError } from "./client";
 export type {
   JqlPresentationResponse,
   JqlQueryInput,

--- a/src/jql/jql.test.ts
+++ b/src/jql/jql.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { JudgevalAPIError, JudgevalJqlClient } from "./client";
+import {
+  JudgevalAPIError,
+  JudgevalJqlClient,
+  JudgevalJqlUnavailableError,
+} from "./client";
 import { eq, traces } from "./index";
 
 const originalFetch = globalThis.fetch;
@@ -95,6 +99,99 @@ describe("public JQL errors", () => {
         hint: "Slow down.",
         retryAfterSeconds: 2,
       });
+    }
+  });
+
+  const respondNotFound = (message: string) => {
+    globalThis.fetch = (() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ error: "Resource not found", message }), {
+          status: 404,
+        }),
+      )) as unknown as typeof fetch;
+  };
+
+  const jqlClient = () =>
+    new JudgevalJqlClient(
+      "https://api.example.com",
+      "api-key",
+      "org-1",
+      "project-1",
+      "demo",
+    );
+
+  test("explains the feature gate and the missing project on an opaque 404", async () => {
+    respondNotFound("Resource not found");
+
+    try {
+      await jqlClient().query(traces().ids());
+      throw new Error("expected query to fail");
+    } catch (error) {
+      expect(error).toBeInstanceOf(JudgevalJqlUnavailableError);
+      // Existing callers that catch JudgevalAPIError keep working.
+      expect(error).toBeInstanceOf(JudgevalAPIError);
+      const { message } = error as JudgevalJqlUnavailableError;
+      expect(message).toContain("JQL is not enabled for this organization");
+      expect(message).toContain("project 'demo' was not found");
+      expect(message).toContain("Contact Judgment");
+      // The opaque server message must not survive as the user-facing message.
+      expect(message).not.toContain("Resource not found");
+      expect(error).toMatchObject({ status: 404 });
+    }
+  });
+
+  test("does not blame the feature gate when the project is missing", async () => {
+    respondNotFound("Project not found");
+
+    try {
+      await jqlClient().query(traces().ids());
+      throw new Error("expected query to fail");
+    } catch (error) {
+      const { message } = error as JudgevalJqlUnavailableError;
+      expect(message).toBe(
+        "Project 'demo' was not found for this organization.",
+      );
+      expect(message).not.toContain("not enabled");
+    }
+  });
+
+  test("falls back to the project id when no project name is supplied", async () => {
+    respondNotFound("Resource not found");
+    const client = new JudgevalJqlClient(
+      "https://api.example.com",
+      "api-key",
+      "org-1",
+      "project-1",
+    );
+
+    try {
+      await client.query(traces().ids());
+      throw new Error("expected query to fail");
+    } catch (error) {
+      expect((error as JudgevalJqlUnavailableError).message).toContain(
+        "project 'project-1' was not found",
+      );
+    }
+  });
+
+  test("leaves non-404 errors as plain API errors", async () => {
+    globalThis.fetch = (() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({ error: "JQL_INVALID", message: "boom" }),
+          {
+            status: 422,
+          },
+        ),
+      )) as unknown as typeof fetch;
+
+    try {
+      await jqlClient().query(traces().ids());
+      throw new Error("expected query to fail");
+    } catch (error) {
+      expect(error).toBeInstanceOf(JudgevalAPIError);
+      expect(error).not.toBeInstanceOf(JudgevalJqlUnavailableError);
+      expect((error as JudgevalAPIError).message).toBe("boom");
     }
   });
 });


### PR DESCRIPTION
## Summary

A valid JQL query from an organization without the `public_jql` feature flag threw a bare `JudgevalAPIError` carrying the server's `Resource not found`, giving callers nothing to act on. This is the TypeScript half of the fix; the Python half is JudgmentLabs/judgeval#767.

- Added `JudgevalJqlUnavailableError` (subclass of `JudgevalAPIError`) for 404s on JQL routes, exported from both `src/jql/index.ts` and `src/index.ts`
- Mapped the 404 in `JudgevalJqlClient.post` — the single choke point covering `query`, `present`, and `discover`
- Sharpened the message to `Project '<name>' was not found for this organization.` when the server message is `Project not found`
- `JudgevalJqlClient` takes an optional 5th `projectName` argument so the message can use the project name instead of the opaque id, matching Python. Optional, so it is non-breaking, and it falls back to the project id.

**Before**
```
JudgevalAPIError: Resource not found
```

**After**
```
JudgevalJqlUnavailableError: JQL is not enabled for this organization, or
project 'my-project' was not found — the API returns the same 404 for both.
Contact Judgment to enable JQL for your organization.
```

### Why the message names two causes

`judgeval-server` throws `NotFoundError('Resource not found')` when the `public_jql` flag is off, which is byte-identical to the 404 for a missing project, and the published OpenAPI documents 404 as "Project or public JQL endpoint not found". The SDK therefore **cannot** positively identify the disabled flag, and claiming it could would mislead the much more common case of a typo'd project name. Naming both causes plus the next step is the honest maximum available client-side.

One string does discriminate: the org-level gate runs *before* the project lookup server-side, so a `Project not found` message can only come from an already-enabled org. That is used to sharpen the message, with a comment marking the coupling and a safe fallback if the server text ever changes.

### Design notes

- The new error subclasses `JudgevalAPIError`, so existing `instanceof JudgevalAPIError` callers are unaffected (asserted in a test).
- Non-404 errors keep their existing behaviour and raw server message.
- Field names and message text mirror the Python SDK so the two runtimes report the same thing.

### Follow-up (not in this PR)

Worth deciding separately: have `judgeval-server` send a distinguishable `error` code for the flag-off case, letting both SDKs state the cause outright instead of inferring it. If the current ambiguity is intentional non-disclosure, leave it as is.

## Testing

- `bun test` → **118 pass, 0 fail** (7 in `src/jql/jql.test.ts`)
- `bun run check` (`tsc --noEmit` + `oxlint src/`) → 0 errors, 0 warnings
- `prettier` applied to changed files
- New tests: opaque-404 message, sharpened missing-project message, project-id fallback when no name is supplied, `instanceof JudgevalAPIError` back-compat, and non-404 errors left as plain API errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/judgmentlabs/judgeval-js/pull/76" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->