### PR TITLE
fix(trace): keep user span processors when monitoring is disabled

### DIFF
--- a/src/trace/Tracer.test.ts
+++ b/src/trace/Tracer.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import {
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from "@opentelemetry/sdk-trace-base";
+import { JudgmentTracerProvider } from "./JudgmentTracerProvider";
+import { Tracer } from "./Tracer";
+
+describe("Tracer.init span processors", () => {
+  test("keeps user span processors when monitoring is disabled", async () => {
+    const exporter = new InMemorySpanExporter();
+    // No projectName: monitoring is disabled and no network call is made.
+    const tracer = await Tracer.init({
+      spanProcessors: [new SimpleSpanProcessor(exporter)],
+      setActive: false,
+    });
+    try {
+      const span = tracer._tracerProvider.getTracer("test").startSpan("s");
+      span.end();
+      expect(exporter.getFinishedSpans()).toHaveLength(1);
+      expect(exporter.getFinishedSpans()[0]?.name).toBe("s");
+    } finally {
+      JudgmentTracerProvider.getInstance().deregister(tracer);
+      await tracer._tracerProvider.shutdown();
+    }
+  });
+});

--- a/src/trace/Tracer.ts
+++ b/src/trace/Tracer.ts
@@ -164,15 +164,19 @@ export class Tracer extends BaseTracer {
       enableMonitoring,
     );
 
-    if (enableMonitoring) {
+    // User-supplied span processors are attached unconditionally (parity
+    // with the Python SDK): disabled Judgment monitoring must not silently
+    // sever the user's own telemetry pipeline.
+    const spanProcessors = [
+      ...(enableMonitoring ? [tracer.getSpanProcessor()] : []),
+      ...(config.spanProcessors ?? []),
+    ];
+    if (spanProcessors.length > 0) {
       const providerWithProcessor = new NodeTracerProvider({
         resource,
         sampler: config.sampler,
         spanLimits: config.spanLimits,
-        spanProcessors: [
-          tracer.getSpanProcessor(),
-          ...(config.spanProcessors ?? []),
-        ],
+        spanProcessors,
       });
       tracer._tracerProvider = providerWithProcessor;
     }


### PR DESCRIPTION
## Summary

When credentials were missing or project resolution failed at init,
the tracer kept its initial provider, which was constructed with no
span processors at all. That included the processors the user passed
via config.spanProcessors, so a ConsoleSpanExporter wired up for local
development, or a second OTLP pipeline, received nothing. The only
hint was the generic "will not export spans" warning, which talks
about Judgment's own export, not the user's.

The Python tracer attaches user processors regardless of whether
Judgment monitoring is enabled (see span_processors handling in
https://github.com/JudgmentLabs/judgeval/blob/main/src/judgeval/trace/tracer.py);
only its own processor is gated. This does the same: user processors
are attached unconditionally, and only Judgment's processor depends on
enableMonitoring.

## Testing

New src/trace/Tracer.test.ts: init with no project name (monitoring
disabled, no network) plus a SimpleSpanProcessor over an
InMemorySpanExporter, then asserts a span started on the tracer's
provider reaches the user's exporter. This fails on main. bun test,
115 pass / 0 fail. tsc and oxlint clean.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/judgmentlabs/judgeval-js/pull/78" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->