### PR TITLE
fix(trace): only block setActive while a root span is active

### DIFF
--- a/src/trace/JudgmentTracerProvider.test.ts
+++ b/src/trace/JudgmentTracerProvider.test.ts
@@ -204,3 +204,44 @@ describe("BaseTracer.startActiveSpan span lifecycle", () => {
     }
   });
 });
+
+describe("JudgmentTracerProvider.setActive root-span guard", () => {
+  test("blocks activation while a root span is recording", () => {
+    const { proxy, cleanup } = setupProxy();
+    const other = new FakeTracer(new BasicTracerProvider());
+    try {
+      const otelTracer = proxy.getTracer("test");
+      let result: boolean | undefined;
+      otelTracer.startActiveSpan("root-span", (span) => {
+        result = proxy.setActive(other);
+        span.end();
+      });
+      expect(result).toBe(false);
+    } finally {
+      proxy.deregister(other);
+      cleanup();
+    }
+  });
+
+  test("allows activation while only a child span is recording", () => {
+    const { proxy, cleanup } = setupProxy();
+    const previous = proxy.getActiveTracer();
+    const other = new FakeTracer(new BasicTracerProvider());
+    try {
+      const otelTracer = proxy.getTracer("test");
+      let result: boolean | undefined;
+      otelTracer.startActiveSpan("root-span", (root) => {
+        otelTracer.startActiveSpan("child-span", (child) => {
+          result = proxy.setActive(other);
+          child.end();
+        });
+        root.end();
+      });
+      expect(result).toBe(true);
+    } finally {
+      proxy.deregister(other);
+      if (previous) proxy.setActive(previous);
+      cleanup();
+    }
+  });
+});

--- a/src/trace/JudgmentTracerProvider.ts
+++ b/src/trace/JudgmentTracerProvider.ts
@@ -151,7 +151,18 @@ export class JudgmentTracerProvider implements TracerProvider {
   setActive(tracer: BaseTracer): boolean {
     const currentSpan = this.getCurrentSpan();
     if (currentSpan?.isRecording()) {
-      if (trace.getSpan(this.getCurrentContext()) === currentSpan) {
+      // Only a ROOT span blocks activation (parity with the Python SDK's
+      // parent check). SDK spans expose their parent as parentSpanContext
+      // (OTel JS >= 2.x) or parentSpanId (older); absence of both means
+      // the current span is a trace root.
+      const spanRecord = currentSpan as unknown as {
+        parentSpanContext?: unknown;
+        parentSpanId?: unknown;
+      };
+      const isRootSpan =
+        spanRecord.parentSpanContext === undefined &&
+        spanRecord.parentSpanId === undefined;
+      if (isRootSpan) {
         Logger.error(
           "Cannot set_active() while a root span is active. Keeping existing tracer provider.",
         );

--- a/src/workers/WorkerTracerProvider.ts
+++ b/src/workers/WorkerTracerProvider.ts
@@ -105,7 +105,18 @@ export class WorkerTracerProvider implements TracerProvider {
   setActive(tracer: TraceRuntimeTracer): boolean {
     const currentSpan = this.getCurrentSpan();
     if (currentSpan?.isRecording()) {
-      if (trace.getSpan(this.getCurrentContext()) === currentSpan) {
+      // Only a ROOT span blocks activation (parity with the Python SDK's
+      // parent check). SDK spans expose their parent as parentSpanContext
+      // (OTel JS >= 2.x) or parentSpanId (older); absence of both means
+      // the current span is a trace root.
+      const spanRecord = currentSpan as unknown as {
+        parentSpanContext?: unknown;
+        parentSpanId?: unknown;
+      };
+      const isRootSpan =
+        spanRecord.parentSpanContext === undefined &&
+        spanRecord.parentSpanId === undefined;
+      if (isRootSpan) {
         Logger.error(
           "Cannot set_active() while a root span is active. Keeping existing tracer provider.",
         );


### PR DESCRIPTION
## Summary

The guard in setActive that should prevent switching tracers mid-trace
compared trace.getSpan(getCurrentContext()) against getCurrentSpan().
getCurrentSpan() is defined as exactly that expression, so the check
compared a value to itself and was true whenever any recording span
existed. Activating a tracer from inside a child span always failed,
for example creating an OfflineTracer from within an observed
function, and Tracer.init ignores the boolean result, so spans just
kept routing to the previous tracer with only an error log.

The Python provider inspects the current span's parent and refuses
activation only when the span is a trace root (set_active in
https://github.com/JudgmentLabs/judgeval/blob/main/src/judgeval/trace/judgment_tracer_provider.py).
This applies the same check: SDK spans expose parentSpanContext
(OTel JS 2.x) or parentSpanId on older versions, and a span with
neither is a root.

## Testing

Two new tests in src/trace/JudgmentTracerProvider.test.ts: activation
is blocked inside an active root span and allowed inside a child span.
The second case fails on main (the old guard rejected it). bun test,
116 pass / 0 fail. tsc and oxlint clean.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/judgmentlabs/judgeval-js/pull/79" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->