### PR TITLE
feat(jql): scope SDK queries by trace or session

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -55,8 +55,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: JudgmentLabs/judgment-mono
-          # This SDK PR is stacked on judgment-mono#3539. Return this to main
-          # after the parent PR lands.
           ref: refs/pull/3539/head
           token: ${{ secrets.RELEASE_BOT_GITHUB_PAT }}
           persist-credentials: false

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -55,7 +55,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: JudgmentLabs/judgment-mono
-          ref: main
+          # This SDK PR is stacked on judgment-mono#3539. Return this to main
+          # after the parent PR lands.
+          ref: refs/pull/3539/head
           token: ${{ secrets.RELEASE_BOT_GITHUB_PAT }}
           persist-credentials: false
           path: .jql-source/judgment-mono

--- a/README.md
+++ b/README.md
@@ -69,15 +69,15 @@ import { spans } from "judgeval/jql";
 
 const client = await Judgeval.create({ projectName: "my-llm-app" });
 const result = await client.query(spans().rows(), {
-  sessionIds: ["session-123"],
+  traceIds: ["trace-123"],
 });
 ```
 
-`sessionIds` is outside the JQL query object. Judgment resolves the sessions
-within the authenticated organization and project, then narrows every part of
-the query to their traces. If none resolve, the request fails instead of
-falling back to the whole project. The same option works with `present` and
-`discover`.
+`traceIds` and `sessionIds` are mutually exclusive options outside the JQL query
+object. Trace IDs narrow the query directly. Judgment resolves session IDs within
+the authenticated organization and project, then narrows every part of the query
+to their traces. If no session resolves, the request fails instead of falling back
+to the whole project. Both options work with `present` and `discover`.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -65,13 +65,19 @@ the query payload.
 
 ```typescript
 import { Judgeval } from "judgeval";
-import { eq, traces } from "judgeval/jql";
+import { spans } from "judgeval/jql";
 
 const client = await Judgeval.create({ projectName: "my-llm-app" });
-const result = await client.query(
-  traces().where(eq("session", "session-123")).ids(),
-);
+const result = await client.query(spans().rows(), {
+  sessionIds: ["session-123"],
+});
 ```
+
+`sessionIds` is outside the JQL query object. Judgment resolves the sessions
+within the authenticated organization and project, then narrows every part of
+the query to their traces. If none resolve, the request fails instead of
+falling back to the whole project. The same option works with `present` and
+`discover`.
 
 ## Documentation
 

--- a/scripts/generate-jql.ts
+++ b/scripts/generate-jql.ts
@@ -91,7 +91,10 @@ const sourceWirePath = resolve(dirname(builderPath), "wire.ts");
 const sourceWire = readFileSync(sourceWirePath, "utf8");
 const publicSourceWire = sourceWire
   .split("\n")
-  .filter((line) => !line.startsWith("export type Dal"))
+  .filter(
+    (line) =>
+      !line.startsWith("export type Dal") && !line.includes("DalFrameColumn"),
+  )
   .join("\n");
 
 if (sync) {

--- a/scripts/jql-contract/builder.ts
+++ b/scripts/jql-contract/builder.ts
@@ -396,6 +396,12 @@ export const spans = (options?: QueryOptions): QueryBuilder =>
 export const sessions = (options?: QueryOptions): QueryBuilder =>
   query('sessions', options)
 
+export const offline_traces = (options?: QueryOptions): QueryBuilder =>
+  query('offline_traces', options)
+
+export const offline_spans = (options?: QueryOptions): QueryBuilder =>
+  query('offline_spans', options)
+
 function query(source: Source, options?: QueryOptions): QueryBuilder {
   const spec: SourceQuery = { op: 'query', source }
   if (options?.filter !== undefined) spec.filter = toFilter(options.filter)

--- a/scripts/jql-contract/jql-ir.openapi.json
+++ b/scripts/jql-contract/jql-ir.openapi.json
@@ -228,7 +228,9 @@
             "enum": [
               "traces",
               "spans",
-              "sessions"
+              "sessions",
+              "offline_traces",
+              "offline_spans"
             ],
             "title": "Source",
             "type": "string"
@@ -257,7 +259,9 @@
             "dsl": [
               "traces",
               "spans",
-              "sessions"
+              "sessions",
+              "offline_traces",
+              "offline_spans"
             ],
             "example": "traces({ filter: status('error') }).last('7d').ids()",
             "lang": "proj.traces(pred)",
@@ -1410,7 +1414,7 @@
         "x-jql": [
           {
             "category": "filter",
-            "doc": "span cost — span grain",
+            "doc": "cost in USD — per span, summed at traces/sessions",
             "example": "cost({ gt: 0.01 })",
             "lang": "cost(gt=0.01)",
             "model": "CostFilter",
@@ -1501,9 +1505,9 @@
         "x-jql": [
           {
             "category": "filter",
-            "doc": "duration in ms",
-            "example": "duration({ gte: 1000 })",
-            "lang": "duration(gte=1000)",
+            "doc": "duration in nanoseconds",
+            "example": "duration({ gte: 1_000_000_000 })",
+            "lang": "duration(gte=1_000_000_000)",
             "model": "DurationFilter",
             "op": "duration",
             "ts": {
@@ -2013,7 +2017,7 @@
         "x-jql": [
           {
             "category": "filter",
-            "doc": "span name — span grain",
+            "doc": "span name — the root's at traces/sessions",
             "example": "name('agent.run')",
             "lang": "name(\"agent.run\")",
             "model": "NameFilter",
@@ -3231,7 +3235,7 @@
         "x-jql": [
           {
             "category": "stage",
-            "doc": "order the rows",
+            "doc": "order rows; append ` desc` for descending",
             "dsl": [
               "sort"
             ],
@@ -3346,6 +3350,7 @@
               "params": [
                 {
                   "name": "by",
+                  "optional": true,
                   "ts_type": "string | BucketExpr | (string | BucketExpr)[] | undefined",
                   "wire": "by"
                 },
@@ -4122,7 +4127,10 @@
               {
                 "enum": [
                   "traces",
-                  "spans"
+                  "spans",
+                  "sessions",
+                  "offline_traces",
+                  "offline_spans"
                 ],
                 "type": "string"
               },
@@ -4202,7 +4210,7 @@
               ],
               [
                 "fields",
-                "standard fields usable for filters, groups, and aggregates",
+                "standard fields, each carrying the operations it supports at that source",
                 "`source` (required), `limit`"
               ],
               [

--- a/scripts/jql-contract/public-openapi.json
+++ b/scripts/jql-contract/public-openapi.json
@@ -283,7 +283,7 @@
           "trace_ids": {
             "minItems": 1,
             "maxItems": 1000,
-            "description": "Traces to bind directly to the query within the authenticated organization and project.",
+            "description": "Traces to bind directly to the query within the authenticated organization and project. Use offline trace IDs for offline query sources.",
             "type": "array",
             "items": {
               "minLength": 1,
@@ -295,7 +295,7 @@
           "session_ids": {
             "minItems": 1,
             "maxItems": 1000,
-            "description": "Sessions to resolve to a trace-scoped query within the authenticated organization and project.",
+            "description": "Live sessions to resolve to a trace-scoped query within the authenticated organization and project. Unavailable for offline query sources.",
             "type": "array",
             "items": {
               "minLength": 1,

--- a/scripts/jql-contract/public-openapi.json
+++ b/scripts/jql-contract/public-openapi.json
@@ -278,6 +278,18 @@
             "maximum": 10000,
             "type": "integer"
           },
+          "trace_ids": {
+            "minItems": 1,
+            "maxItems": 1000,
+            "description": "Traces to bind directly to the query within the authenticated organization and project.",
+            "type": "array",
+            "items": {
+              "minLength": 1,
+              "maxLength": 512,
+              "pattern": ".*\\S.*",
+              "type": "string"
+            }
+          },
           "session_ids": {
             "minItems": 1,
             "maxItems": 1000,

--- a/scripts/jql-contract/public-openapi.json
+++ b/scripts/jql-contract/public-openapi.json
@@ -270,7 +270,9 @@
         "additionalProperties": false,
         "$id": "PublicJqlRequest",
         "type": "object",
-        "required": ["query"],
+        "required": [
+          "query"
+        ],
         "properties": {
           "query": {},
           "limit": {
@@ -307,7 +309,12 @@
       "PublicJqlQueryResponse": {
         "$id": "PublicJqlQueryResponse",
         "type": "object",
-        "required": ["query_id", "rows", "row_count", "elapsed_ms"],
+        "required": [
+          "query_id",
+          "rows",
+          "row_count",
+          "elapsed_ms"
+        ],
         "properties": {
           "query_id": {
             "type": "string"
@@ -348,7 +355,12 @@
       "PublicJqlPresentationResponse": {
         "$id": "PublicJqlPresentationResponse",
         "type": "object",
-        "required": ["query_id", "presentation", "frame", "elapsed_ms"],
+        "required": [
+          "query_id",
+          "presentation",
+          "frame",
+          "elapsed_ms"
+        ],
         "properties": {
           "query_id": {
             "type": "string"
@@ -371,7 +383,10 @@
       "PublicJqlErrorResponse": {
         "$id": "PublicJqlErrorResponse",
         "type": "object",
-        "required": ["error", "message"],
+        "required": [
+          "error",
+          "message"
+        ],
         "properties": {
           "error": {
             "type": "string"

--- a/scripts/jql-contract/public-openapi.json
+++ b/scripts/jql-contract/public-openapi.json
@@ -270,27 +270,32 @@
         "additionalProperties": false,
         "$id": "PublicJqlRequest",
         "type": "object",
-        "required": [
-          "query"
-        ],
+        "required": ["query"],
         "properties": {
           "query": {},
           "limit": {
             "minimum": 1,
             "maximum": 10000,
             "type": "integer"
+          },
+          "session_ids": {
+            "minItems": 1,
+            "maxItems": 1000,
+            "description": "Sessions to resolve to a trace-scoped query within the authenticated organization and project.",
+            "type": "array",
+            "items": {
+              "minLength": 1,
+              "maxLength": 512,
+              "pattern": ".*\\S.*",
+              "type": "string"
+            }
           }
         }
       },
       "PublicJqlQueryResponse": {
         "$id": "PublicJqlQueryResponse",
         "type": "object",
-        "required": [
-          "query_id",
-          "rows",
-          "row_count",
-          "elapsed_ms"
-        ],
+        "required": ["query_id", "rows", "row_count", "elapsed_ms"],
         "properties": {
           "query_id": {
             "type": "string"
@@ -331,12 +336,7 @@
       "PublicJqlPresentationResponse": {
         "$id": "PublicJqlPresentationResponse",
         "type": "object",
-        "required": [
-          "query_id",
-          "presentation",
-          "frame",
-          "elapsed_ms"
-        ],
+        "required": ["query_id", "presentation", "frame", "elapsed_ms"],
         "properties": {
           "query_id": {
             "type": "string"
@@ -359,10 +359,7 @@
       "PublicJqlErrorResponse": {
         "$id": "PublicJqlErrorResponse",
         "type": "object",
-        "required": [
-          "error",
-          "message"
-        ],
+        "required": ["error", "message"],
         "properties": {
           "error": {
             "type": "string"

--- a/scripts/jql-contract/wire.ts
+++ b/scripts/jql-contract/wire.ts
@@ -56,4 +56,3 @@ export type StageAnyFilter = Schemas['StageAnyFilter']
 export type StageNotFilter = Schemas['StageNotFilter']
 export type PresentationField = Schemas['PresentationField']
 export type OverAgg = Schemas['OverAgg']
-

--- a/scripts/jql-contract/wire.ts
+++ b/scripts/jql-contract/wire.ts
@@ -56,3 +56,5 @@ export type StageAnyFilter = Schemas['StageAnyFilter']
 export type StageNotFilter = Schemas['StageNotFilter']
 export type PresentationField = Schemas['PresentationField']
 export type OverAgg = Schemas['OverAgg']
+
+export type FieldFormat = NonNullable<PresentationField['format']>

--- a/src/Judgeval.ts
+++ b/src/Judgeval.ts
@@ -153,7 +153,7 @@ export class Judgeval {
     });
   }
 
-  /** Run a structured, tenant-scoped JQL query for this project. */
+  /** Run JQL for this project, optionally narrowed by `options.sessionIds`. */
   query(
     query: JqlQueryInput,
     options?: JqlRequestOptions,
@@ -161,7 +161,7 @@ export class Judgeval {
     return this.jqlClient().query(query, options);
   }
 
-  /** Run a chart or table JQL query for this project. */
+  /** Run a chart or table JQL query, optionally narrowed by session. */
   present(
     query: PresentationQuery,
     options?: JqlRequestOptions,
@@ -169,7 +169,7 @@ export class Judgeval {
     return this.jqlClient().present(query, options);
   }
 
-  /** Discover project-scoped JQL catalog values. */
+  /** Discover JQL catalog values, optionally narrowed by session. */
   discover(
     kind: DiscoveryKind,
     options?: DiscoveryOptions & JqlRequestOptions,

--- a/src/Judgeval.ts
+++ b/src/Judgeval.ts
@@ -153,7 +153,7 @@ export class Judgeval {
     });
   }
 
-  /** Run JQL for this project, optionally narrowed by `options.sessionIds`. */
+  /** Run JQL for this project, optionally narrowed by trace or session IDs. */
   query(
     query: JqlQueryInput,
     options?: JqlRequestOptions,
@@ -161,7 +161,7 @@ export class Judgeval {
     return this.jqlClient().query(query, options);
   }
 
-  /** Run a chart or table JQL query, optionally narrowed by session. */
+  /** Run a chart or table JQL query, optionally narrowed by trace or session IDs. */
   present(
     query: PresentationQuery,
     options?: JqlRequestOptions,
@@ -169,7 +169,7 @@ export class Judgeval {
     return this.jqlClient().present(query, options);
   }
 
-  /** Discover JQL catalog values, optionally narrowed by session. */
+  /** Discover JQL catalog values, optionally narrowed by trace or session IDs. */
   discover(
     kind: DiscoveryKind,
     options?: DiscoveryOptions & JqlRequestOptions,

--- a/src/jql/builder.ts
+++ b/src/jql/builder.ts
@@ -400,6 +400,12 @@ export const spans = (options?: QueryOptions): QueryBuilder =>
 export const sessions = (options?: QueryOptions): QueryBuilder =>
   query("sessions", options);
 
+export const offline_traces = (options?: QueryOptions): QueryBuilder =>
+  query("offline_traces", options);
+
+export const offline_spans = (options?: QueryOptions): QueryBuilder =>
+  query("offline_spans", options);
+
 function query(source: Source, options?: QueryOptions): QueryBuilder {
   const spec: SourceQuery = { op: "query", source };
   if (options?.filter !== undefined) spec.filter = toFilter(options.filter);

--- a/src/jql/client.ts
+++ b/src/jql/client.ts
@@ -10,6 +10,8 @@ import type { components as PublicComponents } from "./generated/public-api";
 
 export interface JqlRequestOptions {
   limit?: number;
+  /** Narrow the query directly to these traces. Mutually exclusive with sessionIds. */
+  traceIds?: string[];
   /** Narrow the query to traces resolved from these sessions. */
   sessionIds?: string[];
   signal?: AbortSignal;
@@ -65,9 +67,11 @@ export class JudgevalJqlClient {
     kind: DiscoveryKind,
     options: DiscoveryOptions & JqlRequestOptions = {},
   ): Promise<JqlQueryResponse> {
-    const { signal, limit, sessionIds, ...discoveryOptions } = options;
+    const { signal, limit, traceIds, sessionIds, ...discoveryOptions } =
+      options;
     return this.query(discovery(kind, discoveryOptions), {
       limit,
+      traceIds,
       sessionIds,
       signal,
     });
@@ -78,6 +82,9 @@ export class JudgevalJqlClient {
     query: Query | PresentationQuery,
     options: JqlRequestOptions,
   ): Promise<T> {
+    if (options.traceIds !== undefined && options.sessionIds !== undefined) {
+      throw new TypeError("traceIds and sessionIds are mutually exclusive");
+    }
     const response = await fetch(
       `${this.baseUrl.replace(/\/+$/, "")}/v1/projects/${encodeURIComponent(this.projectId)}/${path}`,
       {
@@ -90,6 +97,9 @@ export class JudgevalJqlClient {
         body: JSON.stringify({
           query,
           ...(options.limit === undefined ? {} : { limit: options.limit }),
+          ...(options.traceIds === undefined
+            ? {}
+            : { trace_ids: options.traceIds }),
           ...(options.sessionIds === undefined
             ? {}
             : { session_ids: options.sessionIds }),

--- a/src/jql/client.ts
+++ b/src/jql/client.ts
@@ -67,10 +67,9 @@ export class JudgevalJqlClient {
     kind: DiscoveryKind,
     options: DiscoveryOptions & JqlRequestOptions = {},
   ): Promise<JqlQueryResponse> {
-    const { signal, limit, traceIds, sessionIds, ...discoveryOptions } =
-      options;
+    const { signal, traceIds, sessionIds, ...discoveryOptions } = options;
     return this.query(discovery(kind, discoveryOptions), {
-      limit,
+      limit: options.limit,
       traceIds,
       sessionIds,
       signal,

--- a/src/jql/client.ts
+++ b/src/jql/client.ts
@@ -10,6 +10,8 @@ import type { components as PublicComponents } from "./generated/public-api";
 
 export interface JqlRequestOptions {
   limit?: number;
+  /** Narrow the query to traces resolved from these sessions. */
+  sessionIds?: string[];
   signal?: AbortSignal;
 }
 
@@ -63,9 +65,12 @@ export class JudgevalJqlClient {
     kind: DiscoveryKind,
     options: DiscoveryOptions & JqlRequestOptions = {},
   ): Promise<JqlQueryResponse> {
-    const { signal, ...discoveryOptions } = options;
-    const { limit } = options;
-    return this.query(discovery(kind, discoveryOptions), { limit, signal });
+    const { signal, limit, sessionIds, ...discoveryOptions } = options;
+    return this.query(discovery(kind, discoveryOptions), {
+      limit,
+      sessionIds,
+      signal,
+    });
   }
 
   private async post<T>(
@@ -85,6 +90,9 @@ export class JudgevalJqlClient {
         body: JSON.stringify({
           query,
           ...(options.limit === undefined ? {} : { limit: options.limit }),
+          ...(options.sessionIds === undefined
+            ? {}
+            : { session_ids: options.sessionIds }),
         }),
         signal: options.signal,
       },

--- a/src/jql/generated/api.ts
+++ b/src/jql/generated/api.ts
@@ -68,7 +68,12 @@ export interface components {
        * Source
        * @enum {string}
        */
-      source: "traces" | "spans" | "sessions";
+      source:
+        | "traces"
+        | "spans"
+        | "sessions"
+        | "offline_traces"
+        | "offline_spans";
       time?: components["schemas"]["TimeSpec"] | null;
     };
     /** AllFilter */
@@ -896,7 +901,9 @@ export interface components {
        */
       op: "discovery";
       /** Source */
-      source?: ("traces" | "spans") | null;
+      source?:
+        | ("traces" | "spans" | "sessions" | "offline_traces" | "offline_spans")
+        | null;
       time?: components["schemas"]["TimeSpec"] | null;
       /** Value */
       value?: unknown;

--- a/src/jql/generated/public-api.ts
+++ b/src/jql/generated/public-api.ts
@@ -239,9 +239,9 @@ export interface components {
     PublicJqlRequest: {
       query: unknown;
       limit?: number;
-      /** @description Traces to bind directly to the query within the authenticated organization and project. */
+      /** @description Traces to bind directly to the query within the authenticated organization and project. Use offline trace IDs for offline query sources. */
       trace_ids?: string[];
-      /** @description Sessions to resolve to a trace-scoped query within the authenticated organization and project. */
+      /** @description Live sessions to resolve to a trace-scoped query within the authenticated organization and project. Unavailable for offline query sources. */
       session_ids?: string[];
     };
     PublicJqlQueryResponse: {

--- a/src/jql/generated/public-api.ts
+++ b/src/jql/generated/public-api.ts
@@ -239,6 +239,8 @@ export interface components {
     PublicJqlRequest: {
       query: unknown;
       limit?: number;
+      /** @description Traces to bind directly to the query within the authenticated organization and project. */
+      trace_ids?: string[];
       /** @description Sessions to resolve to a trace-scoped query within the authenticated organization and project. */
       session_ids?: string[];
     };

--- a/src/jql/generated/public-api.ts
+++ b/src/jql/generated/public-api.ts
@@ -239,6 +239,8 @@ export interface components {
     PublicJqlRequest: {
       query: unknown;
       limit?: number;
+      /** @description Sessions to resolve to a trace-scoped query within the authenticated organization and project. */
+      session_ids?: string[];
     };
     PublicJqlQueryResponse: {
       query_id: string;

--- a/src/jql/jql.test.ts
+++ b/src/jql/jql.test.ts
@@ -16,7 +16,7 @@ test("emits the canonical session-to-trace-ids JSON", () => {
   });
 });
 
-test("sends only public query fields and tenant headers", async () => {
+test("sends session scope with the public query fields and tenant headers", async () => {
   let request: Request | undefined;
   globalThis.fetch = ((input, init) => {
     request =
@@ -42,26 +42,41 @@ test("sends only public query fields and tenant headers", async () => {
     "project-1",
   );
 
-  const response = await client.query(
-    traces().where(eq("session", "session-1")).ids(),
-    { limit: 25 },
-  );
-
-  expect(request?.url).toBe(
-    "https://api.example.com/v1/projects/project-1/query",
-  );
-  expect(request?.headers.get("Authorization")).toBe("Bearer api-key");
-  expect(request?.headers.get("X-Organization-Id")).toBe("org-1");
-  expect(await request?.json()).toEqual({
-    query: {
-      op: "query",
-      source: "traces",
-      filter: { op: "eq", field: "session", value: "session-1" },
-      select: { op: "ids" },
-    },
+  const response = await client.query(traces().ids(), {
     limit: 25,
+    sessionIds: ["session-1"],
   });
-  expect(response.rows).toEqual([{ trace_id: "trace-1" }]);
+
+  expect({
+    request: {
+      url: request?.url,
+      authorization: request?.headers.get("Authorization"),
+      organizationId: request?.headers.get("X-Organization-Id"),
+      body: await request?.json(),
+    },
+    response,
+  }).toEqual({
+    request: {
+      url: "https://api.example.com/v1/projects/project-1/query",
+      authorization: "Bearer api-key",
+      organizationId: "org-1",
+      body: {
+        query: {
+          op: "query",
+          source: "traces",
+          select: { op: "ids" },
+        },
+        limit: 25,
+        session_ids: ["session-1"],
+      },
+    },
+    response: {
+      query_id: "q-1",
+      rows: [{ trace_id: "trace-1" }],
+      row_count: 1,
+      elapsed_ms: 4,
+    },
+  });
 });
 
 describe("public JQL errors", () => {
@@ -84,17 +99,32 @@ describe("public JQL errors", () => {
       "project-1",
     );
 
-    try {
-      await client.query(traces().ids());
-      throw new Error("expected query to fail");
-    } catch (error) {
-      expect(error).toBeInstanceOf(JudgevalAPIError);
-      expect(error).toMatchObject({
-        status: 429,
-        code: "JQL_RATE_LIMITED",
-        hint: "Slow down.",
-        retryAfterSeconds: 2,
-      });
-    }
+    const caught = await (async () => {
+      try {
+        await client.query(traces().ids());
+        throw new Error("expected query to fail");
+      } catch (error) {
+        return error;
+      }
+    })();
+    expect(
+      caught instanceof JudgevalAPIError
+        ? {
+            name: caught.name,
+            message: caught.message,
+            status: caught.status,
+            code: caught.code,
+            hint: caught.hint,
+            retryAfterSeconds: caught.retryAfterSeconds,
+          }
+        : caught,
+    ).toEqual({
+      name: "JudgevalAPIError",
+      message: "Retry later.",
+      status: 429,
+      code: "JQL_RATE_LIMITED",
+      hint: "Slow down.",
+      retryAfterSeconds: 2,
+    });
   });
 });

--- a/src/jql/jql.test.ts
+++ b/src/jql/jql.test.ts
@@ -16,7 +16,7 @@ test("emits the canonical session-to-trace-ids JSON", () => {
   });
 });
 
-test("sends session scope with the public query fields and tenant headers", async () => {
+test("sends trace scope with the public query fields and tenant headers", async () => {
   let request: Request | undefined;
   globalThis.fetch = ((input, init) => {
     request =
@@ -44,7 +44,7 @@ test("sends session scope with the public query fields and tenant headers", asyn
 
   const response = await client.query(traces().ids(), {
     limit: 25,
-    sessionIds: ["session-1"],
+    traceIds: ["trace-1"],
   });
 
   expect({
@@ -67,7 +67,7 @@ test("sends session scope with the public query fields and tenant headers", asyn
           select: { op: "ids" },
         },
         limit: 25,
-        session_ids: ["session-1"],
+        trace_ids: ["trace-1"],
       },
     },
     response: {
@@ -76,6 +76,62 @@ test("sends session scope with the public query fields and tenant headers", asyn
       row_count: 1,
       elapsed_ms: 4,
     },
+  });
+});
+
+test("sends session scope outside the JQL query object", async () => {
+  let request: Request | undefined;
+  globalThis.fetch = ((input, init) => {
+    request =
+      input instanceof Request
+        ? input
+        : new Request(input instanceof URL ? input.toString() : input, init);
+    return Promise.resolve(
+      Response.json({ query_id: "q-1", rows: [], row_count: 0, elapsed_ms: 1 }),
+    );
+  }) as typeof fetch;
+  const client = new JudgevalJqlClient(
+    "https://api.example.com/",
+    "api-key",
+    "org-1",
+    "project-1",
+  );
+
+  await client.query(traces().ids(), { sessionIds: ["session-1"] });
+
+  expect(await request?.json()).toEqual({
+    query: {
+      op: "query",
+      source: "traces",
+      select: { op: "ids" },
+    },
+    session_ids: ["session-1"],
+  });
+});
+
+test("rejects trace and session scope together before fetch", async () => {
+  let fetchCalls = 0;
+  globalThis.fetch = (() => {
+    fetchCalls += 1;
+    return Promise.reject(new Error("must not run"));
+  }) as unknown as typeof fetch;
+  const client = new JudgevalJqlClient(
+    "https://api.example.com/",
+    "api-key",
+    "org-1",
+    "project-1",
+  );
+
+  const error = await client
+    .query(traces().ids(), {
+      traceIds: ["trace-1"],
+      sessionIds: ["session-1"],
+    })
+    .catch((caught) => caught);
+
+  expect({ error, fetchCalls }).toEqual({
+    error: new TypeError("traceIds and sessionIds are mutually exclusive"),
+    fetchCalls: 0,
   });
 });
 

--- a/src/jql/jql.test.ts
+++ b/src/jql/jql.test.ts
@@ -109,6 +109,42 @@ test("sends session scope outside the JQL query object", async () => {
   });
 });
 
+test("keeps discovery limit in the query and request envelope", async () => {
+  let request: Request | undefined;
+  globalThis.fetch = ((input, init) => {
+    request =
+      input instanceof Request
+        ? input
+        : new Request(input instanceof URL ? input.toString() : input, init);
+    return Promise.resolve(
+      Response.json({ query_id: "q-1", rows: [], row_count: 0, elapsed_ms: 1 }),
+    );
+  }) as typeof fetch;
+  const client = new JudgevalJqlClient(
+    "https://api.example.com/",
+    "api-key",
+    "org-1",
+    "project-1",
+  );
+
+  await client.discover("fields", {
+    source: "traces",
+    limit: 5,
+    traceIds: ["trace-1"],
+  });
+
+  expect(await request?.json()).toEqual({
+    query: {
+      op: "discovery",
+      kind: "fields",
+      limit: 5,
+      source: "traces",
+    },
+    limit: 5,
+    trace_ids: ["trace-1"],
+  });
+});
+
 test("rejects trace and session scope together before fetch", async () => {
   let fetchCalls = 0;
   globalThis.fetch = (() => {

--- a/src/jql/wire.ts
+++ b/src/jql/wire.ts
@@ -55,3 +55,5 @@ export type StageAnyFilter = Schemas["StageAnyFilter"];
 export type StageNotFilter = Schemas["StageNotFilter"];
 export type PresentationField = Schemas["PresentationField"];
 export type OverAgg = Schemas["OverAgg"];
+
+export type FieldFormat = NonNullable<PresentationField["format"]>;


### PR DESCRIPTION
## Summary

- add mutually exclusive `traceIds` and `sessionIds` request options for `query`, `present`, and `discover`
- serialize them as public `trace_ids` / `session_ids` request-envelope fields outside canonical JQL JSON
- reject combined trace + session scope locally before `fetch`
- regenerate the public transport types and document trace/session-scoped queries
- preserve exact full-value transport assertions for both scope paths
- validate generated SDK output against the exact head of parent PR JudgmentLabs/judgment-mono#3539

## Testing

- `bun test` — 116 passed
- `bun run check`
- `bun run build`
- canonical regeneration from JudgmentLabs/judgment-mono#3539 followed by `git diff --exit-code -- src/jql`

## Stack and rollout

Depends on JudgmentLabs/judgment-mono#3539. Merge and deploy the public JQL gateway before releasing this SDK change.

The PR parity workflow is temporarily pinned to `refs/pull/3539/head` so the stacked change is validated without weakening the generated-contract check. Return it to `main` after the parent lands.