### PR TITLE
ci(jql): compare parity against mono main

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: JudgmentLabs/judgment-mono
-          ref: refs/pull/3539/head
+          ref: main
           token: ${{ secrets.RELEASE_BOT_GITHUB_PAT }}
           persist-credentials: false
           path: .jql-source/judgment-mono


### PR DESCRIPTION
## Summary

- return the JQL parity checkout from the temporary `refs/pull/3539/head` pin to `judgment-mono/main` now that JudgmentLabs/judgment-mono#3539 has merged
- confirm regeneration from mono main produces no SDK artifact changes

## Testing

- regeneration from `judgment-mono/main` followed by an exact no-diff check across the checked-in JQL contract and generated output
- `bun test` — 117 passed
- `bun run check`
- `bun run build`
